### PR TITLE
Add pipeline to sync technical documentation to the website repo

### DIFF
--- a/.github/workflows/publish-technical-documentation.yml
+++ b/.github/workflows/publish-technical-documentation.yml
@@ -1,0 +1,39 @@
+name: "publish-technical-documentation"
+
+on:
+  push:
+    branches:
+    - "main"
+    paths:
+    - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+    - name: "Build website"
+      run: |
+        docker run -v ${PWD}/docs/sources:/hugo/content/docs/writers-toolkit -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+
+  sync:
+    runs-on: "ubuntu-latest"
+    needs: "test"
+    steps:
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+
+    - name: "Clone website-sync Action"
+      run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
+    - name: "Publish to website repository"
+      uses: "./.github/actions/website-sync"
+      id: "publish"
+      with:
+        repository: "grafana/website"
+        branch: "master"
+        host: "github.com"
+        github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+        source_folder: "docs/sources"
+        target_folder: "content/docs/writers-toolkit"


### PR DESCRIPTION
Should not be merged until https://github.com/grafana/website/pull/9299/ is merged.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>