### PR TITLE
Replace "our" with "Grafana Labs"

### DIFF
--- a/docs/sources/writing-guide/_index.md
+++ b/docs/sources/writing-guide/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Writing guide"
 menuTitle: "Writing guide"
-description: “Learn about Grafana's technical documentation writing guidelines”
+description: “Learn about Grafana’s technical documentation writing guidelines”
 aliases: ["/docs/writers-toolkit/latest/writing-guidelines/"]
 weight: 100
 Keywords:
@@ -11,8 +11,8 @@ Keywords:
 
 # Writing guide
 
-These guidelines are for anyone who are interested in improving our technical content. They are intended to guide you on your documentation journey, whether you are requesting a change, editing a topic, or writing up a new set of documentation for an entirely new product or feature from scratch.
+These guidelines are for anyone who are interested in improving Grafana Labs technical content. They are intended to guide you on your documentation journey, whether you are requesting a change, editing a topic, or writing up a new set of documentation for an entirely new product or feature from scratch.
 <!-- vale Grafana.Exclamation = NO -->
-We hope you find what you are looking for - if not, do provide us with the feedback, so we can keep making this writing guide better and better!
+We hope you find what you are looking for - if not, do provide us with the feedback, so we can keep making this writing guide better and better.
 <!-- vale Grafana.Exclamation = YES -->
 


### PR DESCRIPTION
I like that contributors to Grafana Labs documentation can at least share in the sentiment that they "own" (in quotes) the technical documentation that they are contributing to. "Our" is covered by the license verbiage, strictly speaking.