### PR TITLE
Create action for issues and PRs

### DIFF
--- a/.github/issue_and_pr_commands.json
+++ b/.github/issue_and_pr_commands.json
@@ -1,0 +1,10 @@
+[   
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]


### PR DESCRIPTION
With PR #43, this PR automates assigning issues to projects. This PR uses a github action that we use in other projects and is triggered on label events and when the labels match type/docs it adds it to the technical documentation project

Note - we may need support to add a new secret to this repository called GH_BOT_ACCESS_TOKEN as it is required by this action to be able to work properly