### PR TITLE
Create auto assign workflow

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,23 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]    
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_and_pr_commands 


### PR DESCRIPTION
With PR #42, this PR automates assigning issues to projects. This PR uses a github action that we use in other projects and is triggered on label events and when the labels match type/docs it adds it to the technical documentation project

Additional changes

We may need support to add a new secret to this repository called GH_BOT_ACCESS_TOKEN as it is required by this action to be able to work properly