### PR TITLE
Note possibility of a release branch cut before a release

### DIFF
--- a/docs/sources/writing-guide/tooling-and-workflows/backporting/index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/backporting/index.md
@@ -28,7 +28,7 @@ After the pull request is merged, the GitHub bot `grafanabot` creates a follow-u
 If `grafanabot` is unable to automatically backport the changes, it comments on the first pull request with instructions about how to backport the change manually.
 
 In repositories such as `grafana/grafana`, engineers sometimes create a new branch for a release well before the release has shipped.
-If you intend to publish content against an imminent release, check for the existence of a backport label for the upcoming version when filing and also before merging.
+If you intend to publish content against an imminent release, check for the existence of a backport label for the upcoming version when filing, and also before merging, and apply the label if it exists or has been added to ensure the content is automatically backported to the upcoming version's documentation.
 
 If you decide to _not_ backport a change, use the `no-backport` GitHub label.
 


### PR DESCRIPTION
Grafana v9.1 cut the `v9.1.x` branch two weeks before the final v9.1 release. This created an edge case in the docs publishing and Grafana release process that resulted in docs content and changes being merged against the `main` branch but not being published in the `/latest/` docs when v9.1 was released. Those docs PRs needed to be backported to the `v9.1.x` branch even if Grafana v9.1 had not been released and the v9.1 docs had not yet been published to `/latest/`.

Note this and adjust the workflow diagram accordingly.