### PR TITLE
Remove erroneous `ref` documentation

### DIFF
--- a/docs/sources/writing-guide/references/index.md
+++ b/docs/sources/writing-guide/references/index.md
@@ -14,7 +14,7 @@ keywords:
 
 # Links and cross references
 
-Hugo has builtin shortcodes for creating links to documents.
+Hugo has built-in shortcodes for creating links to documents.
 The `ref` and `relref` shortcodes display the absolute and relative permalinks to a document, respectively.
 
 > **Note:** For Hugo's purposes, you can't address other versions of the docs, such as a version-specific archived docs set (`https://grafana.com/docs/grafana/v8.5/`, etc.) or `/next/` docs for links in content residing in `/latest/`, using Hugo references.


### PR DESCRIPTION
The `ref` shortcode is not evaluated differently to the `relref` shortcode, it just returns an absolute permalink instead of a relative one.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>