### PR TITLE
Replace quotes with italics.

### DIFF
--- a/docs/sources/style-guide/capitalization-punctuation/index.md
+++ b/docs/sources/style-guide/capitalization-punctuation/index.md
@@ -31,18 +31,18 @@ The names of people, places, and products take initial capitals because they are
 
 ### Grafana-specific capitalization guidelines
 - Menu and submenu titles always use sentence case: capitalize the first word, and lowercase the rest.
-  - "Dashboards" when referring to the submenu title.
-  - "Keyboard shortcuts" when referring to the submenu topic.
+  - _Dashboards_ when referring to the submenu title.
+  - _Keyboard shortcuts_ when referring to the submenu topic.
 - Generic and plural versions are always lowercase.
-  - Lowercase "dashboard" when referring to a dashboard generally.
-  - Lowercase "dashboards" when referring to multiple dashboards.
+  - Lowercase _dashboard_ when referring to a dashboard generally.
+  - Lowercase _dashboards_ when referring to multiple dashboards.
 - **Exceptions:** If a term is lowercased in the Grafana UI, then match the UI.
 
 ### Kubernetes objects
 
 When referring to Kubernetes objects, such as Jobs, Pods, and StatefulSets, capitalizing them makes it clear that you are not talking about generic jobs and pods.
 
-In the first use, introduce the object as "Kubernetes XX", then use it alone in subsequent uses.
+In the first use, introduce the object as _Kubernetes XX_, then use it alone in subsequent uses.
 
 **Examples:**
 
@@ -54,9 +54,9 @@ In the first use, introduce the object as "Kubernetes XX", then use it alone in 
 Refer to the following punctuation guidelines when you write technical content.
 
 - After a period, add one space, not two.
-- In a series, use serial commas before "and" or "or."
-  - Example: "During lunch, we enjoyed quiche, quinoa, and kale salad.”
-- Do not abbreviate and with an ampersand (&).
+- In a series, use serial commas before _and_ or _or_.
+  - Example: "During lunch, we enjoyed quiche, quinoa, _and_ kale salad.”
+- Do not abbreviate _and_ with an ampersand (_&_).
   - Exception: If the UI uses an ampersand, match the UI.
 - At the end of a paragraph, remove extra space characters.
 - Use italics to indicate paths within a web application, and greater-than symbols (>) to indicate path separators.


### PR DESCRIPTION
Rationale: reserve double quotes for spoken language or complete example sentences.