### PR TITLE
Replace blind with generic.

### DIFF
--- a/docs/sources/style-guide/style-conventions/index.md
+++ b/docs/sources/style-guide/style-conventions/index.md
@@ -105,7 +105,7 @@ For more guidance, refer to [Lists](https://developers.google.com/style/lists) i
 
 You should use "Refer to" instead of "See" or "Check out" when referencing another document.
 
-Give the reader a sense of what to expect in the reference. Don't use blind references, such as "Refer to [this file]."
+Give the reader a sense of what to expect in the reference. Don't use generic references, such as "Refer to [this file]."
 
 As much as possible, use the exact title of the page or section you are linking to as the link text.
 


### PR DESCRIPTION
Rationale: it is not clear what _blind_ means in this context; it is clearer to use the term _generic_ because it matches the lack of specification needed for a reference.