### PR TITLE
Markdown, standardize page and add description lists

### DIFF
--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -220,5 +220,5 @@ You can include comments that do not display in published output:
 
 ## Shortcodes
 
-Shortcodes are predefined templates that let you reuse snippets across the Grafana website. To learn how to use shortcodes, refer to [Shortcodes]({{< relref "../shortcodes/" >}}).
+Shortcodes are predefined templates that let you reuse snippets of technical documentation. To learn how to use shortcodes, refer to [Shortcodes]({{< relref "../shortcodes/" >}}).
 


### PR DESCRIPTION
- Adds examples for how to create description lists. Shows example of common nested syntax, because most users will probably want to bold the term (`<dt>` element).
- Standardizes the page:
   - indicate that codefences are HTML or markdown. The site already adds syntax highlighting for HTML. Markdown, I'm not sure. But even without syntax highlighting, we might add a syntax highlighter later.
   - Remove bold **example** pseudo-headings when not necessary. In most cases, the snippet and rendered text provide a self-evident example. The example  element was creating noise, IMO.
   - Other minor standardizations, like capitalizing markdown

