### PR TITLE
docs: adds steps heading element to task topic guidelines

### DIFF
--- a/docs/sources/writing-guide/topic-types/task/index.md
+++ b/docs/sources/writing-guide/topic-types/task/index.md
@@ -31,6 +31,8 @@ A _task_ topic includes the following elements:
 - Additionally, this section can include decisions the user should make or permissions they need to confirm before starting the task.
 - If there are no prerequisites, do not include this section.
 
+**Steps heading**: The steps heading indicates that the steps are about to begin.
+
 **Stem sentence:** The stem sentence introduces the steps. Use the following convention when you write a stem sentence:
 - To [name of task], follow these steps:
 - Example: To create a dashboard, follow these steps:


### PR DESCRIPTION
This PR adds the missing steps heading element to the task topic guidelines.