### PR TITLE
Reduce number of clicks to templates.

### DIFF
--- a/docs/sources/writing-guide/_index.md
+++ b/docs/sources/writing-guide/_index.md
@@ -15,6 +15,8 @@ Keywords:
 The writing guide defines the structured authoring environment we use to create documentation at Grafana Labs. If you write technical documentation for Grafana Labs, familiarize yourself with the guidelines that follow.
 
 The guidelines are for anyone who is interested in improving Grafana Labs' technical content. They are intended to guide you on your documentation journey, whether you are requesting a change, editing a topic, or writing a set of documentation for a new product or feature from scratch.
+
+If you are already familiar with the guidelines, feel free to get started from one of the [templates](https://github.com/grafana/writers-toolkit/tree/main/docs/static/templates).
 <!-- vale Grafana.Exclamation = NO -->
 We hope you find what you are looking for. If you don't, provide us with the feedback, so we can continuously improve this writing guide.
 <!-- vale Grafana.Exclamation = YES -->


### PR DESCRIPTION
As a contributor who has read the guidelines and writes frequently, I want to access the templates quickly so I can start writing. Alternatively, I could bookmark the GitHub location instead of the guide. However, I want to keep _Writers’ Toolkit_ as my source of overall truth and would prefer to remember only that I need to go there for access to information quickly.