### PR TITLE
Add links to Markdown references.

### DIFF
--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -17,8 +17,9 @@ keywords:
 
 This Markdown guide helps keep contributions consistent across all Grafana Labs documentation. Refer to the guide and update it as needed when a subject matter expert (SME) answers a question about Markdown syntax, or a decision is made about how to apply Markdown.
 
-Grafana uses the default Hugo Markdown parser named Goldmark.
-The flavor is compliant with CommonMark, with some extended features.
+We use the static site generator [Hugo](https://gohugo.io/) to generate the web site for the documentation.
+
+Hugo uses a Markdown parser named Goldmark, which supports the CommonMark flavor of Markdown, with some extended features.  Here is the [CommonMark specification](https://spec.commonmark.org/), and a [quick reference guide](https://commonmark.org/help/) for CommonMark.
 
 **Write in sentence case** throughout all technical documentation, be it long-form text or microcopy within a UI:
 


### PR DESCRIPTION
We don't come right out and say anywhere that we're using Hugo (we assume you know, we should actually say we use it).

Also adding links to:
Hugo web site
CommonMark specification
CommonMark quick reference