### PR TITLE
Fix frontmatter table and use comma for restrictive modifier

### DIFF
--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -41,18 +41,17 @@ The following list describes what each element does and provides guidelines for 
 :  Becomes the document title element. Often browsers display this in the tab for the page.
 
    It doesn't need to precisely match the `menuTitle`.
-   The title should be optimized for search engines. May be surrounded by double quote marks ("). Do not use smart quotes.
+   Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
 `description`
 
-:  Displays as a clue to users about what the page should include on social (Twitter and the like),
-   though not as much by a search engine.
+:  On social media, such as Twitter, displays as a clue to users about what the page includes.
 
-   The number of characters vary by media, but use them wisely.
-   Provide enough information to guide users to the content by describing what content is provided using the link.
+   The number of characters vary by media, so make the description concise.
+   Provide enough information to guide users to the content by describing what content the link leads to.
    Often, this doesn’t need to be original prose&mdash;you can often scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
-   It won't cause harm if it's too long, it will simply truncate in the displayed media.
-   May be surrounded by double quote marks ("). Do not use smart quotes.
+   If it's too long, it is harmlessly truncated on social media.
+   Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
 `aliases`
 
@@ -61,14 +60,14 @@ The following list describes what each element does and provides guidelines for 
 
 `weight`
 
-:  Determines the placement of the topic within the left-hand sidebar of our website, with smaller numbers placing the topic higher in the guide. Pages with the same weight have lexicographic ordering.
+:  Determines the placement of the topic within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic higher in the guide. Pages with the same weight have lexicographic ordering.
 
-   Use increments of `100` for all other content files, because doing so eliminates much of the need to re-order existing topics when new topics are added. Weights are per directory.
+   Use increments of `100` for all other content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
 
 `keywords`
 
-:  Keywords are used by the website to link to related pages in the “related content” sections.
-   They do not appear in the resulting HTML source for the page and have no effect on SEO.
+:  The website uses keywords to link to related pages in the _Related content_ sections.
+   They do not appear in the resulting HTML source for the page and do not affect SEO.
 
    Ideally, use single terms as opposed to phrases.
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -34,54 +34,45 @@ Here’s a correctly built example:
       - architecture
     ---
 
-The following table describes each front matter element in detail.
+The following list describes what each element does and provides guidelines for its content.
 
-<table>
-    <thead>
-        <tr>
-            <th>Element</th>
-            <th>Description</th>
-            <th>Guideline</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td align="left" valign="top">[title]</td>
-            <td align="left" valign="top">Required. <br><br>The [title] displays as the H1 on the page. <br><br>The [title] becomes the document title element. Often browsers display this in the tab for the page.</td>
-            <td align="left" valign="top">Does not need to precisely match the menuTitle. The title should be optimized for search engines. <br><br>May be surrounded by double quote marks (<code>"</code>). Do not use smart quotes.</td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">[menuTitle]</td>
-            <td align="left" valign="top">The [menuTitle] is useful for having a distinct sidebar entry perhaps in the case that the title is too long to display nicely in the sidebar as the title on the website in the left-hand sidebar.<br><br>Note: Not all repos support [menuTitle].</td>
-            <td align="left" valign="top">Does not need to precisely match the title. The menuTitle does not need to be optimized for search engines. <br><br>May be surrounded by double quote marks (<code>"</code>). Do not use smart quotes.</td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">[description]</td>
-            <td align="left" valign="top">The [description] text displays as a clue to users about what the page should include on social (Twitter and the like), though not as much by a search engine.</td>
-            <td align="left" valign="top">The number of characters vary by media, but use them wisely. <br><br>Provide enough information to guide users to the content by describing what content is provided using the link. Often, this doesn’t need to be original prose - you can often scan the first few paragraphs to pluck the appropriate terms/phrases into the description. <br><br>It won't cause harm if it's too long, it will simply truncate in the displayed media.  <br><br>May be surrounded by double quote marks (<code>"</code>). Do not use smart quotes.</td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">[aliases]</td>
-            <td align="left" valign="top">Provides an HTML redirect from the pages in the list to the current page.</td>
-            <td align="left" valign="top">Described in detail in <a href="#hugo-aliases">Hugo aliases</a>.
-            </td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">[weight]</td>
-            <td align="left" valign="top">The [weight] determines the placement of the topic within the left-hand sidebar of our website, with smaller numbers placing the topic higher in the guide. <br><br>Pages with the same weight have lexicographic ordering. </td>
-            <td align="left" valign="top">Use increments of `100` for all other content files, because doing so eliminates much of the need to re-order existing topics when new topics are added. <br><br>Weights are per web directory.</a>
-            </td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">[keywords]</td>
-            <td align="left" valign="top">Keywords are used by the website to link to related pages in the “related content” sections. https://github.com/grafana/website/blob/master/config/_default/config.yaml#L85 <br><br>They do not appear in the resulting HTML source for the page and have no effect on SEO.</td>
-            <td align="left" valign="top">Ideally, use single terms as opposed to phrases.</a>
-            </td>
-        </tr>
-    </tbody>
-</table>
+`title` **Required.**
 
-## [Title] v [MenuTitle] example
+:  Becomes the document title element. Often browsers display this in the tab for the page.
+
+   It doesn't need to precisely match the `menuTitle`.
+   The title should be optimized for search engines. May be surrounded by double quote marks ("). Do not use smart quotes.
+
+`description`
+
+:  Displays as a clue to users about what the page should include on social (Twitter and the like),
+   though not as much by a search engine.
+
+   The number of characters vary by media, but use them wisely.
+   Provide enough information to guide users to the content by describing what content is provided using the link.
+   Often, this doesn’t need to be original prose&mdash;you can often scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
+   It won't cause harm if it's too long, it will simply truncate in the displayed media.
+   May be surrounded by double quote marks ("). Do not use smart quotes.
+
+`aliases`
+
+:  Provides an HTML redirect from the pages in the list to the current page.
+   Described in detail in Hugo aliases.
+
+`weight`
+
+:  Determines the placement of the topic within the left-hand sidebar of our website, with smaller numbers placing the topic higher in the guide. Pages with the same weight have lexicographic ordering.
+
+   Use increments of `100` for all other content files, because doing so eliminates much of the need to re-order existing topics when new topics are added. Weights are per directory.
+
+`keywords`
+
+:  Keywords are used by the website to link to related pages in the “related content” sections.
+   They do not appear in the resulting HTML source for the page and have no effect on SEO.
+
+   Ideally, use single terms as opposed to phrases.
+
+## Example with different page and menu titles
 
 ```
 ---

--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -17,7 +17,7 @@ keywords:
 
 This Markdown guide helps keep contributions consistent across all Grafana Labs documentation. Refer to the guide and update it as needed when a subject matter expert (SME) answers a question about Markdown syntax, or a decision is made about how to apply Markdown.
 
-Grafana uses the default Hugo Markdown parser named Goldmark.
+Grafana documentation is rendered with Goldmark, which is the default Markdown parser for Hugo.
 The flavor is compliant with CommonMark, with some extended features.
 
 **Write in sentence case** throughout all technical documentation, be it long-form text or microcopy within a UI:


### PR DESCRIPTION
- https://github.com/grafana/writers-toolkit/commit/d3d3b9588e29f93939ea8f280838f3ceac32f585 fixes #167.  It uses a definition list, which renders as follows on my local build:
  
  ![image](https://user-images.githubusercontent.com/47385188/213005394-21c9918c-cf9f-46d0-983f-da6ccca9ea91.png)

  Until the docker image updates I can't see how it looks in new styling, but I checked the formatting on another hugo site and it was fine.
  
  I didn't change the content, but I think that's out of scope for this issue.
  
 - https://github.com/grafana/writers-toolkit/commit/fc4614df5d03053fc47538dd43b6506fcf2bd2b4 sets off a sentence with comma and relative clause. The original as an an unrestricted phrase sounded off to my ear. It's not very important in the scheme of things but it's important to me @osg-grafana :pray: :pray:  