### PR TITLE
Add draft true to frontmatter/index.md

### DIFF
--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -73,7 +73,7 @@ The following list describes what each element does and provides guidelines for 
 
 `draft: true`
 
-:  When present, this option prevents a page from being published on the documentation website.
+:  When present, this option prevents Hugo from rendering the content.  Use the command line flag `--buildDrafts` to generate content marked as `draft: true`.
 
 ## Example with different page and menu titles
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -71,6 +71,10 @@ The following list describes what each element does and provides guidelines for 
 
    Ideally, use single terms as opposed to phrases.
 
+`draft: true`
+
+:  When present, this option prevents a page from being published on the documentation website.
+
 ## Example with different page and menu titles
 
 ```


### PR DESCRIPTION
This PR adds information about the `draft: true` option to prevent a draft document from being published on the website. 