### PR TITLE
Add OSS product label to all Writers' Toolkit pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,5 +1,8 @@
 ---
 cascade:
+  labels:
+    products:
+      - oss
   public_docs: true
   search_section: Writers' Toolkit
   search_type: doc


### PR DESCRIPTION
Check with `$ make docs`, browse to http://localhost:3002/docs/writers-toolkit and confirm that the "Open source" label is present before the title.