### PR TITLE
Add labels front matter documentation

### DIFF
--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -18,69 +18,74 @@ Use YAML for all front matter.
 In certain presentations, all front matter characters might render literally.
 For this reason, _do not_ include any special Markdown formatting, like italics or monospace, in front matter.
 
-
 Here’s a correctly built example:
 
 ```
-    ---
-    title: About Grafana Mimir architecture
-    menuTitle: Architecture
-    description: Learn more about Grafana Mimir’s microservices-based architecture.
-    aliases:
-      - /docs/mimir/latest/old-architecture/
-    weight: 100
-    keywords:
-      - Mimir
-      - microservices
-      - architecture
-    ---
+---
+title: About Grafana Mimir architecture
+menuTitle: Architecture
+description: Learn more about Grafana Mimir’s microservices-based architecture.
+aliases:
+  - /docs/mimir/latest/old-architecture/
+weight: 100
+keywords:
+  - Mimir
+  - microservices
+  - architecture
+---
+
 # About Grafana Mimir architecture
 ```
 
-The following list describes what each element does and provides guidelines for its content.
+## Reference
 
-`title` **Required.**
+The following headings describe what each element does and provides guidelines for its content.
 
-:  Becomes the document title element. Often browsers display this in the tab for the page.
+### title
 
-   It doesn't need to precisely match the `menuTitle`.
-   Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
+**Required.**
 
-`description`
+Becomes the document title element. Often browsers display this in the tab for the page.
 
-:  On social media, such as Twitter, displays as a clue to users about what the page includes.
+It doesn't need to precisely match the `menuTitle`.
+Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
-   The number of characters vary by media, so make the description concise.
-   Provide enough information to guide users to the content by describing what content the link leads to.
-   Often, this doesn’t need to be original prose&mdash;you can often scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
-   If it's too long, it is harmlessly truncated on social media.
-   Use double quotes (`"`) to surround the title. Do not use smart quotes.
+If the `doc-validator` linter has been implemented on your repository, your topic heading must match the title in the metadata.
 
-`aliases`
+### description
 
-:  Provides an HTML redirect from the pages in the list to the current page.
-   Described in detail in Hugo aliases.
+**Required.**
 
-`weight`
+On social media, such as Twitter, displays as a clue to users about what the page includes.
 
-:  Determines the placement of the topic within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic higher in the guide. Pages with the same weight have lexicographic ordering.
+The number of characters vary by media, so make the description concise.
+Provide enough information to guide users to the content by describing what content the link leads to.
+Often, this doesn’t need to be original prose—you can often scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
+If it's too long, it is harmlessly truncated on social media.
+Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
-   Use increments of `100` for all other content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
+### aliases
 
-`keywords`
+Provides an HTML redirect from the pages in the list to the current page.
+For more information, refer to [Hugo aliases](#hugo-aliases).
 
-:  The website uses keywords to link to related pages in the _Related content_ sections.
-   They do not appear in the resulting HTML source for the page and do not affect SEO.
+### weight
 
-   Ideally, use single terms as opposed to phrases.
+Determines the placement of the topic within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic higher in the guide. Pages with the same weight have lexicographic ordering.
 
-`draft: true`
+Use increments of `100` for all other content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
 
-:  When present, this option prevents Hugo from rendering the content.  Use the command line flag `--buildDrafts` to generate content marked as `draft: true`.
+### keywords
 
-`# heading`
+The website uses keywords to link to related pages in the _Related content_ sections.
+They do not appear in the resulting HTML source for the page and do not affect SEO.
 
-: If the `docs-validator` linter has been implemented on your repository, your topic heading must match the title in the metadata.
+Ideally, use single terms as opposed to phrases.
+
+### draft
+
+When set to `true`, this option prevents Hugo from rendering the content.
+Use the command line flag `--buildDrafts` to generate content marked as `draft: true`.
 
 ## Example with different page and menu titles
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -87,7 +87,7 @@ For `labels.products`, the supported values and the resulting published labels a
 Labels can be inherited through cascading front matter.
 Each project has a set of default labels defined in the root `_index.md` file for the project.
 
-For versioned projects, the `_index.md` file resides in the website repository.
+For versioned projects, the `_index.md` file resides in the `website` repository.
 For unversioned projects, the `_index.md` file resides in the project repository.
 
 If the default labels are incorrect for a page, or directory of pages, you should update the labels.

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -102,7 +102,7 @@ labels:
     - enterprise
 ```
 
-For a directory of pages, if all pages describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front matter should include the following:
+For a **directory of pages** that describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front matter should include the following:
 
 ```yaml
 cascade:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -75,7 +75,7 @@ Ideally, use single terms as opposed to phrases.
 
 ### labels
 
-Used to add labels that appear before the topic title.
+Use the `labels` key to add one or more values that you want to appear before the topic title on the published page.
 Only certain labels are supported.
 
 For `labels.products`, the supported values and the resulting website labels are:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -104,7 +104,7 @@ labels:
 
 For a directory of pages, if all pages describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front matter should include the following:
 
-```
+```yaml
 cascade:
   labels:
     products:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -91,6 +91,7 @@ For versioned projects, the `_index.md` file resides in the `website` repository
 For unversioned projects, the `_index.md` file resides in the project’s repository.
 
 If the default labels are incorrect for a page or directory of pages, update the labels.
+Also, if you are adding a new page, consider whether the default labels are appropriate.
 For each page, include a label in the `labels.products` sequence for every product that the page relates to.
 
 For example, if a **single page** describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -85,7 +85,7 @@ For `labels.products`, the supported values and the resulting published labels a
 - `oss`: "Open source"
 
 Labels can be inherited through cascading front matter.
-Each project has a set of default labels defined in the root `_index.md` file for the project.
+Each project has a set of default labels that are defined in the root `_index.md` file of the project.
 
 For versioned projects, the `_index.md` file resides in the `website` repository.
 For unversioned projects, the `_index.md` file resides in the project repository.

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -25,6 +25,9 @@ Here’s a correctly built example:
 aliases:
   - /docs/mimir/latest/old-architecture/
 description: Learn more about Grafana Mimir’s microservices-based architecture.
+labels:
+  products:
+    - oss
 keywords:
   - Mimir
   - microservices
@@ -69,6 +72,19 @@ The website uses keywords to link to related pages in the _Related content_ sect
 They do not appear in the resulting HTML source for the page and do not affect SEO.
 
 Ideally, use single terms as opposed to phrases.
+
+### labels
+
+Used to add labels that appear before the topic title.
+Only certain labels are supported.
+
+For `labels.products`, the supported values and the resulting website labels are:
+
+- `cloud`: "Grafana Cloud"
+- `enterprise`: "Enterprise"
+- `oss`: "Open source"
+
+A page should include a label in the `labels.products` sequence for every product that the page is relevant to.
 
 ### title
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -22,16 +22,16 @@ Here’s a correctly built example:
 
 ```
 ---
-title: About Grafana Mimir architecture
-menuTitle: Architecture
-description: Learn more about Grafana Mimir’s microservices-based architecture.
 aliases:
   - /docs/mimir/latest/old-architecture/
-weight: 100
+description: Learn more about Grafana Mimir’s microservices-based architecture.
 keywords:
   - Mimir
   - microservices
   - architecture
+menuTitle: Architecture
+title: About Grafana Mimir architecture
+weight: 100
 ---
 
 # About Grafana Mimir architecture
@@ -41,16 +41,10 @@ keywords:
 
 The following headings describe what each element does and provides guidelines for its content.
 
-### title
+### aliases
 
-**Required.**
-
-Becomes the document title element. Often browsers display this in the tab for the page.
-
-It doesn't need to precisely match the `menuTitle`.
-Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
-
-If the `doc-validator` linter has been implemented on your repository, your topic heading must match the title in the metadata.
+Provides an HTML redirect from the pages in the list to the current page.
+For more information, refer to [Hugo aliases](#hugo-aliases).
 
 ### description
 
@@ -64,16 +58,10 @@ Often, this doesn’t need to be original prose—you can often scan the first f
 If it's too long, it is harmlessly truncated on social media.
 Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
-### aliases
+### draft
 
-Provides an HTML redirect from the pages in the list to the current page.
-For more information, refer to [Hugo aliases](#hugo-aliases).
-
-### weight
-
-Determines the placement of the topic within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic higher in the guide. Pages with the same weight have lexicographic ordering.
-
-Use increments of `100` for all other content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
+When set to `true`, this option prevents Hugo from rendering the content.
+Use the command line flag `--buildDrafts` to generate content marked as `draft: true`.
 
 ### keywords
 
@@ -82,10 +70,22 @@ They do not appear in the resulting HTML source for the page and do not affect S
 
 Ideally, use single terms as opposed to phrases.
 
-### draft
+### title
 
-When set to `true`, this option prevents Hugo from rendering the content.
-Use the command line flag `--buildDrafts` to generate content marked as `draft: true`.
+**Required.**
+
+Becomes the document title element. Often browsers display this in the tab for the page.
+
+It doesn't need to precisely match the `menuTitle`.
+Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
+
+If the `doc-validator` linter has been implemented on your repository, your topic heading must match the title in the metadata.
+
+### weight
+
+Determines the placement of the topic within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic higher in the guide. Pages with the same weight have lexicographic ordering.
+
+Use increments of `100` for all other content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
 
 ## Example with different page and menu titles
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -84,7 +84,32 @@ For `labels.products`, the supported values and the resulting website labels are
 - `enterprise`: "Enterprise"
 - `oss`: "Open source"
 
+Labels can be inherited through cascading front matter.
+Each project has a set of default labels defined in the root `_index.md` file for the project.
+
+For versioned projects, the `_index.md` file resides in the website repository.
+For unversioned projects, the `_index.md` file resides in the project repository.
+
+If the default labels are incorrect for a page, or directory of pages, you should update the labels.
 A page should include a label in the `labels.products` sequence for every product that the page is relevant to.
+
+For a single page, if the page describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:
+
+```yaml
+labels:
+  products:
+    - cloud
+    - enterprise
+```
+
+For a directory of pages, if all pages describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front mattershould include the following:
+
+```
+cascade:
+  labels:
+    products:
+      - cloud
+```
 
 ### title
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -102,7 +102,7 @@ labels:
     - enterprise
 ```
 
-For a directory of pages, if all pages describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front mattershould include the following:
+For a directory of pages, if all pages describe a feature only available in Grafana Cloud, the branch bundle `_index.md` file front matter should include the following:
 
 ```
 cascade:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -93,7 +93,7 @@ For unversioned projects, the `_index.md` file resides in the project’s reposi
 If the default labels are incorrect for a page or directory of pages, update the labels.
 For each page, include a label in the `labels.products` sequence for every product that the page relates to.
 
-For a single page, if the page describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:
+For example, if a **single page** describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:
 
 ```yaml
 labels:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -91,7 +91,7 @@ For versioned projects, the `_index.md` file resides in the `website` repository
 For unversioned projects, the `_index.md` file resides in the project repository.
 
 If the default labels are incorrect for a page or directory of pages, update the labels.
-A page should include a label in the `labels.products` sequence for every product that the page is relevant to.
+For each page, include a label in the `labels.products` sequence for every product that the page relates to.
 
 For a single page, if the page describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:
 

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -78,7 +78,7 @@ Ideally, use single terms as opposed to phrases.
 Use the `labels` key to add one or more values that you want to appear before the topic title on the published page.
 Only certain labels are supported.
 
-For `labels.products`, the supported values and the resulting website labels are:
+For `labels.products`, the supported values and the resulting published labels are as follows:
 
 - `cloud`: "Grafana Cloud"
 - `enterprise`: "Enterprise"

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -90,7 +90,7 @@ Each project has a set of default labels that are defined in the root `_index.md
 For versioned projects, the `_index.md` file resides in the `website` repository.
 For unversioned projects, the `_index.md` file resides in the project repository.
 
-If the default labels are incorrect for a page, or directory of pages, you should update the labels.
+If the default labels are incorrect for a page or directory of pages, update the labels.
 A page should include a label in the `labels.products` sequence for every product that the page is relevant to.
 
 For a single page, if the page describes a feature available in Grafana Cloud and Grafana Enterprise, the source file front matter should include the following:

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -88,7 +88,7 @@ Labels can be inherited through cascading front matter.
 Each project has a set of default labels that are defined in the root `_index.md` file of the project.
 
 For versioned projects, the `_index.md` file resides in the `website` repository.
-For unversioned projects, the `_index.md` file resides in the project repository.
+For unversioned projects, the `_index.md` file resides in the project’s repository.
 
 If the default labels are incorrect for a page or directory of pages, update the labels.
 For each page, include a label in the `labels.products` sequence for every product that the page relates to.


### PR DESCRIPTION
Readers should understand the origin of cascading labels and how to override them for single pages or whole directories.