### PR TITLE
Add manage section to TOC terms

### DIFF
--- a/docs/sources/writing-guide/documentation-structure/index.md
+++ b/docs/sources/writing-guide/documentation-structure/index.md
@@ -72,6 +72,7 @@ You can use the following high-level topics to group content. When writing new c
 | _Query data_ | [TraceQL](/docs/tempo/latest/traceql/) | Query languages, query tools, and examples. |
 | _Visualize data_ | [Dashboards](/docs/grafana/latest/dashboards/) | Dashboard concepts and procedures. Link to the definitive source of dashboard documentation, rather than duplicating the information here. |
 | _Alert_ | [Alerting rules](/docs/loki/latest/rules/) | This topic level is used for pages that discuss alerting features, like Grafana Loki's alerting rules. It provides a place for alerting content that is not specific to the Grafana Operations products. |
+| _Manage [product]_ | [Manage users and teams with Grafana Oncall](/docs/grafana-cloud/oncall/configure-user-settings/) | Information about managing a Grafana Labs product. |
 | _Monitor [product]_ | [Monitor Mimir](/docs/mimir/latest/operators-guide/monitor-grafana-mimir/) | Information about using tools to monitor a Grafana Labs product. |
 | _References_ | [HTTP API reference](/docs/grafana-cloud/api-reference/http-api/) | APIs, configuration references, SDKs, and more. Material that is usually not procedural. |
 


### PR DESCRIPTION
This PR adds "Manage" as a top-level TOC term to the documentation structure topic. 