### PR TITLE
Document why relative aliases are used in versioned documentation

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -9,8 +9,6 @@ cascade:
 title: Writers’ Toolkit
 menuTitle: Writers' Toolkit
 description: Writers' Toolkit for technical documentation provided by Grafana Labs
-aliases:
-  - /docs/writers-toolkit/latest/
 weight: 100
 keywords:
   - writing guide

--- a/docs/sources/style-guide/_index.md
+++ b/docs/sources/style-guide/_index.md
@@ -2,8 +2,6 @@
 title: Style guide
 menuTitle: Style guide
 description: Style guide for Grafana Labs
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/
 weight: 100
 keywords:
   - Grafana

--- a/docs/sources/style-guide/capitalization-punctuation/index.md
+++ b/docs/sources/style-guide/capitalization-punctuation/index.md
@@ -1,8 +1,6 @@
 ---
 title: Capitalization and punctuation
 description: Capitalization and punctuaton
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/capitalization-punctuation/
 weight: 400
 keywords:
   - capitalization
@@ -30,6 +28,7 @@ Use all-caps capitalization exclusively for abbreviations, such as `API`, `HTTP`
 The names of people, places, and products take initial capitals because they are proper nouns.
 
 ### Grafana-specific capitalization guidelines
+
 - Menu and submenu titles always use sentence case: capitalize the first word, and lowercase the rest.
   - _Dashboards_ when referring to the submenu title.
   - _Keyboard shortcuts_ when referring to the submenu topic.
@@ -54,7 +53,7 @@ In the first use, introduce the object as _Kubernetes XX_, then use it alone in 
 Refer to the following punctuation guidelines when you write technical content.
 
 - After a period, add one space, not two.
-- When listing a series of items, insert a comma before _and_ or _or_.  This is known as using serial commas or the Oxford comma.
+- When listing a series of items, insert a comma before _and_ or _or_. This is known as using serial commas or the Oxford comma.
   - Example: "During lunch, we enjoyed quiche, quinoa, _and_ kale salad.”
 - Do not abbreviate _and_ with an ampersand (_&_).
   - Exception: If the UI uses an ampersand, match the UI.

--- a/docs/sources/style-guide/inclusive-writing/index.md
+++ b/docs/sources/style-guide/inclusive-writing/index.md
@@ -1,8 +1,6 @@
 ---
 title: Inclusive writing
 description: Inclusive writing
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/style-conventions/inclusive-writing/
 weight: 400
 keywords:
   - inclusive writing
@@ -50,6 +48,7 @@ If you use an acronym, first write out each word in the acronym on first use, an
 Understanding idioms typically requires cultural context. Grafana’s users are all around the world, and many are non-native English speakers. Therefore, avoid idioms and idiomatic puns.
 
 For example, some common American English idioms:
+
 - “Costs an arm and a leg”
 - “Hit the nail on the head”
 - “Bite off more than you can chew”
@@ -65,6 +64,7 @@ Not sure you believe us? Here are some British idioms that you probably won’t 
 Cultural references are references that relate to the culture of a community, country, continent, and so on.
 
 **Examples:**
+
 - “Her ambition is a clear reflection of the American dream.”
 - “I'm so glad you came to help like a good samaritan.”
 - “They grew up in a typical nuclear family.”

--- a/docs/sources/style-guide/style-conventions/index.md
+++ b/docs/sources/style-guide/style-conventions/index.md
@@ -1,8 +1,6 @@
 ---
 title: Style conventions
 description: Style conventions
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/style-conventions/
 weight: 200
 keywords:
   - style conventions
@@ -58,7 +56,7 @@ Simple, direct communication is the key to effective technical communication.
 - Don't use buzzwords or jargon.
 - Keep paragraphs to three sentences or less.
   - Condense the text, add more headings, or do both.
-- Use contractions in common and negative cases to express a conversational style: _you’re_, _that’s_, _isn’t_ or _don’t, for example.
+- Use contractions in common and negative cases to express a conversational style: _you’re_, _that’s_, _isn’t_ or \_don’t, for example.
 
 Make content relevant to the user's context. The more familiar you are with the user’s context, the better you can communicate without using a lot of words.
 
@@ -137,7 +135,7 @@ A caution warns the user to proceed with caution. A caution emphasizes a course 
 
 ### Warnings
 
-A warning informs the user not to do something.  Warnings are usually reserved for actions that, if performed, could cause harm to hardware, software, or data. 
+A warning informs the user not to do something. Warnings are usually reserved for actions that, if performed, could cause harm to hardware, software, or data.
 
 For example:
 

--- a/docs/sources/style-guide/ux-writing/index.md
+++ b/docs/sources/style-guide/ux-writing/index.md
@@ -1,8 +1,6 @@
 ---
 title: UX writing
-description: Guidelines on creating text, style, and tone in UI components 
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/ux-writing/
+description: Guidelines on creating text, style, and tone in UI components
 weight: 500
 keywords:
   - Grafana
@@ -11,17 +9,18 @@ keywords:
 
 # UX writing
 
-These guidelines provide guidance on creating text, style, and tone in the different components that make up the UI. They help us build UIs that enhance the user experience, are easy to use, consistent, and inclusive. These guidelines focus on UX writing. For more details on UI elements, refer to the [Grafana Storybook React component library](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-intro--page). 
+These guidelines provide guidance on creating text, style, and tone in the different components that make up the UI. They help us build UIs that enhance the user experience, are easy to use, consistent, and inclusive. These guidelines focus on UX writing. For more details on UI elements, refer to the [Grafana Storybook React component library](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-intro--page).
 
 ## Our top tips for writing UI text
 
-Read some of our tips for writing clear and concise UX microcopy. 
+Read some of our tips for writing clear and concise UX microcopy.
 
 ### Use a voice that is friendly and not too formal
 
-Be conversational but don't use the voice you use when texting a friend. 
-- Talk to our users like you're an engineer casually talking to other engineers. 
-- Sound human and show empathy. We're here to help people complete their work and resolve issues. 
+Be conversational but don't use the voice you use when texting a friend.
+
+- Talk to our users like you're an engineer casually talking to other engineers.
+- Sound human and show empathy. We're here to help people complete their work and resolve issues.
 - Refrain from using "please" in your UI text.
 
 **Use:**
@@ -32,15 +31,16 @@ Be conversational but don't use the voice you use when texting a friend.
 
 > Here is a guide to set up SLOs.
 
-### Be clear and concise 
+### Be clear and concise
 
-The more words you use, the more time you waste. 
-- Communicate only essential details. 
+The more words you use, the more time you waste.
+
+- Communicate only essential details.
 - Take time to edit what you write to make every word count.
 
 **Use:**
 
-> Save changes 
+> Save changes
 
 **Don't use:**
 
@@ -60,11 +60,11 @@ Use "you" or "your" as though the UI is speaking to the users. Don't use "please
 
 **Use:**
 
-> Refer to [About Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/about-k8s-monitoring/) for details. 
+> Refer to [About Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/about-k8s-monitoring/) for details.
 
 **Don't use:**
 
-> Please refer to [About Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/about-k8s-monitoring/) for details. 
+> Please refer to [About Kubernetes Monitoring](/docs/grafana-cloud/kubernetes-monitoring/about-k8s-monitoring/) for details.
 
 ### Use active voice
 
@@ -72,7 +72,7 @@ Use active voice to make clear who is performing the action.
 
 **Use:**
 
-> The server receives the query. 
+> The server receives the query.
 
 **Don't use:**
 
@@ -84,7 +84,7 @@ Capitalize only the first word in the title, the first word in a subheading afte
 
 **Use:**
 
-> Create and manage dashboards to visualize your data. 
+> Create and manage dashboards to visualize your data.
 
 **Don't use:**
 
@@ -96,19 +96,19 @@ Avoid using UI terms when possible.
 
 **Use:**
 
-> In your Grafana Cloud stack, click **Connections**.  
+> In your Grafana Cloud stack, click **Connections**.
 
 **Don't use:**
 
 > In your Grafana Cloud stack, click the **Connections** button.
- 
+
 ### Use numerals
 
 The guideline for writing numbers in most mediums is to spell out the numbers one through nine. When writing UI text, it's best to use numerals (1 - 9) because they're easier to parse.
 
 **Use:**
 
-> You have 3 messages.  
+> You have 3 messages.
 
 **Don't use:**
 
@@ -140,11 +140,12 @@ Use periods for multiple sentences.
 
 **Use:**
 
-> Metrics, Logs, and Traces are billed based on ingestion. For Metrics, we bill based on the number of active series using the 95th percentile during the period. 
+> Metrics, Logs, and Traces are billed based on ingestion. For Metrics, we bill based on the number of active series using the 95th percentile during the period.
 
 **Don't use:**
 
 > Metrics, Logs, and Traces are billed based on ingestion<p></p><p></p>For Metrics, we bill based on the number of active series using the 95th percentile during the period
+
 ### Write scannable descriptive text
 
 Using long blocks of descriptive text reduces readability. Write important information first and use short, bulleted lists. Use [headings](#headings) to divide content.
@@ -174,7 +175,7 @@ If you'd like us to add a UI element, refer to the template at the bottom of thi
 
 ### Buttons
 
-Use buttons when you want users to take actions, such as adding or creating new records or types of information in an existing system.  
+Use buttons when you want users to take actions, such as adding or creating new records or types of information in an existing system.
 
 - Start button labels with a verb.
 - Aim for using one to two words, with a maximum of four words.
@@ -183,48 +184,48 @@ Use buttons when you want users to take actions, such as adding or creating new 
 
 #### Common use cases for buttons
 
-| Button | When to use it | Examples |
-|---|---|---|
-| Create | Use when you're creating something new, from scratch or from within an existing app. Creating can involve building something (often large) from scratch. | **Create** <p></p> **Create incident** <p></p> **Create entry** |
-| Add | Use when you're adding something into a larger thing. Add extra details to an existing thing. Adding is usually a small or single step, with less work than creating. | **Add details** <p></p> **Add contact** |
-| Save | Save something to a server. | **Save** <p></p> **Save and exit** <p></p> **Save changes** |
-| Edit | Change or update something that already exists. This doesn’t affect the server until the user saves. | **Edit** |
-| Preview | Preview a runtime version of whatever you are working on. This action doesn’t take you away from or override the page you’re already on. | **Preview** |
-| Cancel | Cancel or leave a process. Leave without saving any changes. Although **Cancel** is a common button name, it's better to be specific and name the action that's being cancelled.   | **Cancel** |
-| Close | Close a window. | **Close** |
-| Delete | Permanently delete something from the server. This usually prompts a confirmation modal, asking you to confirm your decision. | **Delete notification policy** <p></p> Deleting this notification policy will permanently remove it. Are you sure you want to delete this policy? <p></p>**Yes, delete** |
-| Remove  | Remove an item from a list. | **Remove** |
+| Button  | When to use it                                                                                                                                                                   | Examples                                                                                                                                                                 |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Create  | Use when you're creating something new, from scratch or from within an existing app. Creating can involve building something (often large) from scratch.                         | **Create** <p></p> **Create incident** <p></p> **Create entry**                                                                                                          |
+| Add     | Use when you're adding something into a larger thing. Add extra details to an existing thing. Adding is usually a small or single step, with less work than creating.            | **Add details** <p></p> **Add contact**                                                                                                                                  |
+| Save    | Save something to a server.                                                                                                                                                      | **Save** <p></p> **Save and exit** <p></p> **Save changes**                                                                                                              |
+| Edit    | Change or update something that already exists. This doesn’t affect the server until the user saves.                                                                             | **Edit**                                                                                                                                                                 |
+| Preview | Preview a runtime version of whatever you are working on. This action doesn’t take you away from or override the page you’re already on.                                         | **Preview**                                                                                                                                                              |
+| Cancel  | Cancel or leave a process. Leave without saving any changes. Although **Cancel** is a common button name, it's better to be specific and name the action that's being cancelled. | **Cancel**                                                                                                                                                               |
+| Close   | Close a window.                                                                                                                                                                  | **Close**                                                                                                                                                                |
+| Delete  | Permanently delete something from the server. This usually prompts a confirmation modal, asking you to confirm your decision.                                                    | **Delete notification policy** <p></p> Deleting this notification policy will permanently remove it. Are you sure you want to delete this policy? <p></p>**Yes, delete** |
+| Remove  | Remove an item from a list.                                                                                                                                                      | **Remove**                                                                                                                                                               |
 
 Refer to the Grafana Storybook React component library for button [usage](https://developers.grafana.com/ui/latest/index.html?path=/docs/buttons-button--basic) and an [example](https://developers.grafana.com/ui/latest/index.html?path=/story/buttons-button--basic).
 
 ## Input fields
 
-Use short and scannable text for input field labels. Use sentence case and front-load your field labels with terms that most clearly describe the values they need to enter in the input field. 
+Use short and scannable text for input field labels. Use sentence case and front-load your field labels with terms that most clearly describe the values they need to enter in the input field.
 
 If you provide instructions for an input field, be clear about limitations, requirements, and available characters for that field. Use a red asterisk for required fields. Use sentence case without punctuation for the instructions, unless there are multiple sentences.
 
-Optionally, you can provide descriptive placeholder text in an input field. If you do so, make your description clear and concise. The placeholder text should be a hint of the value to be expected. 
+Optionally, you can provide descriptive placeholder text in an input field. If you do so, make your description clear and concise. The placeholder text should be a hint of the value to be expected.
 
 **Use:**
 
-> **SLO description** ______________________<p></p>This description appears in a panel next to your SLO status.
+> **SLO description** **********\_\_**********<p></p>This description appears in a panel next to your SLO status.
 
 **Don't use:**
 
-> **SLO description that appears in a panel next to your SLO status.** <p></p> ______________________
+> **SLO description that appears in a panel next to your SLO status.** <p></p> **********\_\_**********
 
 Refer to the Grafana Storybook React component library for button [usage](https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-inlinefield--with-tooltip) and an [example](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-inlinefield--basic).
 
 ## Errors
 
-Make errors visible to users, helpful, and easy to understand. Error messages tell the user what happened and what they can do to fix the error.  
+Make errors visible to users, helpful, and easy to understand. Error messages tell the user what happened and what they can do to fix the error.
 
-- The error headline includes a concise, meaningful summary of the error. Error details provide as much information as possible. 
+- The error headline includes a concise, meaningful summary of the error. Error details provide as much information as possible.
 - Include reasons and instructions for fixing the issue, if possible. Don’t give just the system logs or error titles; try to state how the error was caused and what the user can do to fix it. Assume that some of your users might not understand crash logs and need a simpler description.
 - Write error messages for humans without blame. Don't use overdramatic wording or jargon, and avoid apologies. Give a no-nonsense summary of what went wrong and include the degree of severity, in understandable terms.
-- Like other UI elements, use sentence case, plain language, and active voice in both the  title and details. Do not use the term "invalid" in an error message. Instead use "not valid" if necessary.
+- Like other UI elements, use sentence case, plain language, and active voice in both the title and details. Do not use the term "invalid" in an error message. Instead use "not valid" if necessary.
 
-Refer also to [Alert modals](#alert-modals). 
+Refer also to [Alert modals](#alert-modals).
 
 **Use:**
 
@@ -236,7 +237,7 @@ Refer also to [Alert modals](#alert-modals).
 
 **Use:**
 
-> Complete the required fields marked by *.
+> Complete the required fields marked by \*.
 
 **Don't use:**
 
@@ -250,12 +251,11 @@ Refer also to [Alert modals](#alert-modals).
 
 > Oops, the server appears to be on a break.
 
-
-Refer to the Grafana Storybook React component library for input field [usage](https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-input--with-field-validation) and an [example](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-input--simple). 
+Refer to the Grafana Storybook React component library for input field [usage](https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-input--with-field-validation) and an [example](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-input--simple).
 
 ### Input field validation
 
-Use an input field validation when a text field has formatting requirements. If the validation fails, show the error message directly below the field. 
+Use an input field validation when a text field has formatting requirements. If the validation fails, show the error message directly below the field.
 
 Refer to the Grafana Storybook React component library for an example of an [input field with validation](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-input--with-field-validation).
 
@@ -269,12 +269,12 @@ Assume that some of your users might not understand technical terms and need sim
 
 Alert modals have severity levels (error, warning, info, and success) with different colors used for each level:
 
-| Severity | When to use |
-|---|---|
-| ![Error alert](error.png)| Use an error if an action fails and the user is prevented from completing their task. |
+| Severity                      | When to use                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| ![Error alert](error.png)     | Use an error if an action fails and the user is prevented from completing their task.                                 |
 | ![Warning alert](warning.png) | Use a warning to say "don't do this," for example, if the step might be irreversible, leading to permanent data loss. |
-| ![Info alert](info.png) | Use as a note to provide useful but not critical information. |
-| ![Success alert](success.png) | Use to indicate that an action has completed without errors. |
+| ![Info alert](info.png)       | Use as a note to provide useful but not critical information.                                                         |
+| ![Success alert](success.png) | Use to indicate that an action has completed without errors.                                                          |
 
 ### Actionable instructions
 
@@ -290,9 +290,9 @@ For error messages, provide actionable instructions to help users complete their
 
 ## Confirm modals
 
-Use confirm modals to request the user to confirm an action, for example, a deletion. Confirm modals interrupt the user in their flow and force them to deal with the action in the modal. Only use a modal if this interruption is a good thing, for example, when the cost of an error is high. 
+Use confirm modals to request the user to confirm an action, for example, a deletion. Confirm modals interrupt the user in their flow and force them to deal with the action in the modal. Only use a modal if this interruption is a good thing, for example, when the cost of an error is high.
 
-- Use affirmative actions with verbs in confirmation messages. Direct and actionable language encourages the user to take the next step. 
+- Use affirmative actions with verbs in confirmation messages. Direct and actionable language encourages the user to take the next step.
 - Be sure to also explain the impact and consequences of the options that the user can take. Like other UI elements, use sentence case, plain language, and active voice in the confirmation message title and details.
 
 **Use:**
@@ -307,12 +307,12 @@ Refer to the Grafana Storybook React component library for confirm modal [usage]
 
 ## Tooltips
 
-Use tooltips to identify UI objects, such as icons. Users hover over a UI object to view a box with a description. 
+Use tooltips to identify UI objects, such as icons. Users hover over a UI object to view a box with a description.
 
-- Use tooltips for ancillary information since users only refer to the information if they hover over the object. 
-- Keep tooltips brief, generally fewer than 120 characters. 
+- Use tooltips for ancillary information since users only refer to the information if they hover over the object.
+- Keep tooltips brief, generally fewer than 120 characters.
 - Consider using tooltips for additional in-app documentation as in this example:
-    ![Warning alert](tooltip.png)
+  ![Warning alert](tooltip.png)
 
 Refer to the Grafana Storybook React component library for tooltip modal [usage](https://developers.grafana.com/ui/latest/index.html?path=/docs/overlays-tooltip--basic) and an [example](https://developers.grafana.com/ui/latest/index.html?path=/story/overlays-tooltip--basic).
 
@@ -333,12 +333,12 @@ A heading gives structure to your UI elements. Use headings whenever you need to
 
 ## Links
 
-If your product is complex, you might be unable to provide relevant details concisely in the UI text. In this case, you can provide links to documentation for details.  
+If your product is complex, you might be unable to provide relevant details concisely in the UI text. In this case, you can provide links to documentation for details.
 
-- Use links sparingly. Try first to write concise and complete UI text. If you include a link, make sure the referenced content will help the user with the task they are completing in the UI.  
-- Your link text should be descriptive, telling the user what content they will find upon clicking. Use the exact title of the topic they're linking to so that if the link breaks, they can search for the topic. Like headings, front-load the link text by putting the word people are looking for at the front of your link. 
+- Use links sparingly. Try first to write concise and complete UI text. If you include a link, make sure the referenced content will help the user with the task they are completing in the UI.
+- Your link text should be descriptive, telling the user what content they will find upon clicking. Use the exact title of the topic they're linking to so that if the link breaks, they can search for the topic. Like headings, front-load the link text by putting the word people are looking for at the front of your link.
 - Include the link either at the beginning or end of a sentence, not in the middle. Do not include preceding articles as part of the linked text.
-- For overview text, you can link to relevant overview documentation and Grafana University courses. 
+- For overview text, you can link to relevant overview documentation and Grafana University courses.
 
 **Use**
 
@@ -346,13 +346,13 @@ If your product is complex, you might be unable to provide relevant details conc
 
 ## Additional elements
 
-The UI elements described here are not exhaustive. If you'd like specific types of UI elements added, let us know. Internal contributors can reach out on Slack and external contributors can reach us using our docs@grafana.com email.  
+The UI elements described here are not exhaustive. If you'd like specific types of UI elements added, let us know. Internal contributors can reach out on Slack and external contributors can reach us using our docs@grafana.com email.
 
 Use the following template to provide input.
 
 ### Template
 
-Use this template to add guidelines for UI elements. 
+Use this template to add guidelines for UI elements.
 
 **[UI element name]**
 
@@ -360,15 +360,12 @@ Write an introduction about the element. Say what its intent or purpose is in an
 
 Provide writing guidelines for the element.
 
-Provide links to usage and examples of the element in the [Grafana Storybook React component library](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-intro--page). 
+Provide links to usage and examples of the element in the [Grafana Storybook React component library](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-intro--page).
 
-**Use** 
+**Use**
 
 > Provide an example of how to use the element.
 
 **Don't use**
 
 > Provide an example of how not to use the element.
-
-
-

--- a/docs/sources/style-guide/voice-tone-guidelines/index.md
+++ b/docs/sources/style-guide/voice-tone-guidelines/index.md
@@ -1,8 +1,6 @@
 ---
 title: Voice and tone guidelines
 description: Voice and tone guidelines
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/voice-tone-guidelines/
 weight: 300
 keywords:
   - Grafana
@@ -13,7 +11,7 @@ keywords:
 
 At Grafana, we like our company to sound like a real person.
 
-Voice and tone reflect your attitude and how you convey information. Word choice, **bolding**, *italicizing*, punctuation, and grammar all affect your voice. The tone you choose reflects the urgency of your message and can therefore change depending on the situation.
+Voice and tone reflect your attitude and how you convey information. Word choice, **bolding**, _italicizing_, punctuation, and grammar all affect your voice. The tone you choose reflects the urgency of your message and can therefore change depending on the situation.
 
 Consult the following voice and tone guidelines when you write technical documentation.
 
@@ -29,7 +27,7 @@ Write in a natural and conversational style with language that reflects a positi
 
 A casual tone is accepted in UI copy and supporting material compared to traditional business writing.
 
-As long as they allow for shorter sentences, you can use the words _and_, _but_, and _so_ in moderation. 
+As long as they allow for shorter sentences, you can use the words _and_, _but_, and _so_ in moderation.
 
 Use contractions like _isn't_ for _is not_ to help to convey an informal tone. But [be careful](https://www.grammarly.com/blog/contractions/).
 

--- a/docs/sources/style-guide/write-for-developers/index.md
+++ b/docs/sources/style-guide/write-for-developers/index.md
@@ -1,8 +1,6 @@
 ---
 title: Write for developers
 description: Learn to write documentation for software developers and engineers.
-aliases:
-  - /docs/writers-toolkit/latest/style-guide/write-for-developers/
 weight: 500
 keywords:
   - Grafana
@@ -11,7 +9,7 @@ keywords:
 
 # Write for developers
 
-The guidelines that follow provide suggestions for writing documentation for software developers and engineers. 
+The guidelines that follow provide suggestions for writing documentation for software developers and engineers.
 Follow these tips to write useful API documentation, code examples, and other technical material.
 To learn how to communicate effectively with the developers who enhance and work with the code of Grafana Labs projects or products, read these guidelines in the context of the [Style guide]({{< relref "../../style-guide/" >}}).
 
@@ -23,15 +21,15 @@ Because this type of documentation contains details about code, it's important t
 
 When your readers are developers, you can assume that they are familiar with general programming concepts.
 There is no need to explain elementary ideas. Instead, introduce those concepts and features that are specific to Grafana Labs products.
-For example, instead of covering the fundamentals of UI design  _in general_, explain how Grafana Labs software or APIs _interpret_ those principles.
+For example, instead of covering the fundamentals of UI design _in general_, explain how Grafana Labs software or APIs _interpret_ those principles.
 
 ## Code comments
 
-The foundation of strong documentation is well-written comments in code that are concise, relevant, and current. 
+The foundation of strong documentation is well-written comments in code that are concise, relevant, and current.
 
-For do's and don'ts of writing comments, refer to the [Guidelines for code comments in grafana-* packages](https://github.com/grafana/grafana/blob/main/contribute/style-guides/code-comments.md).
+For do's and don'ts of writing comments, refer to the [Guidelines for code comments in grafana-\* packages](https://github.com/grafana/grafana/blob/main/contribute/style-guides/code-comments.md).
 
-For more general advice, consult one of the reputable [Google Style Guides](https://google.github.io/styleguide/) for your favorite programming language. 
+For more general advice, consult one of the reputable [Google Style Guides](https://google.github.io/styleguide/) for your favorite programming language.
 
 ## Reference docs
 
@@ -45,9 +43,10 @@ But behind every line of auto-generated content is a human author who is respons
 
 When writing documentation that will be used by an auto-generated program to create publishable content, keep the following things in mind:
 
-An auto-generation tool can parse syntax, but when writing documentation that will be used to create automated content, it is up to you to add actionable insights. 
+An auto-generation tool can parse syntax, but when writing documentation that will be used to create automated content, it is up to you to add actionable insights.
+
 - What are the caveats, edge cases, and side effects?
-- What is the bigger picture that is not self-evident in the code? 
+- What is the bigger picture that is not self-evident in the code?
 - In short, what is everything that a developer needs to know to use the code?
 
 > **Note:** It might be difficult to integrate auto-generated content with other documentation, such as relevant sections of _Get started_ guides, tutorials, or detailed code examples. You might need to ask a Docs team member to ensure that your content is properly cross-referenced.
@@ -56,26 +55,27 @@ An auto-generation tool can parse syntax, but when writing documentation that wi
 
 Properly document the most common elements of an API reference, such as the title, parameters, return values, and so on. The following suggestions will help you to write more complete and consistent documentation:
 
-| Element                                               | Description                                                           |
-| ------------------------------------------------- | ----------------------------------------------------------------------- |
-| Title and description       | The name of the element and a description of it in one or two sentences. Use backticks (``) for API names, classes, methods, and so forth, so they display in a fixed-width font. |
-| Syntax | The code signature that defines the element. If it is possible to use multiple programming languages, provide the syntax for each. Put the signature in `code font`. |
-| Parameters | If the element has parameters, specify their descriptions, data types, and state whether they are optional or required. Put the parameters in _italic_. |
-| Return values| If the element returns a value, describe the range of possibilities and the data type. |
-| Error codes| Describe errors or exceptions and the conditions under which they occur. If possible, provide a way to resolve the issue. |
-| Comments | Describe any important information that hasn't been previously included in the title, description, syntax, parameters, or return values. For example, you might explain non-obvious context, make a comparison to similar elements, or provide cautionary notes about potential gotchas. |
+| Element               | Description                                                                                                                                                                                                                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Title and description | The name of the element and a description of it in one or two sentences. Use backticks (``) for API names, classes, methods, and so forth, so they display in a fixed-width font.                                                                                                        |
+| Syntax                | The code signature that defines the element. If it is possible to use multiple programming languages, provide the syntax for each. Put the signature in `code font`.                                                                                                                     |
+| Parameters            | If the element has parameters, specify their descriptions, data types, and state whether they are optional or required. Put the parameters in _italic_.                                                                                                                                  |
+| Return values         | If the element returns a value, describe the range of possibilities and the data type.                                                                                                                                                                                                   |
+| Error codes           | Describe errors or exceptions and the conditions under which they occur. If possible, provide a way to resolve the issue.                                                                                                                                                                |
+| Comments              | Describe any important information that hasn't been previously included in the title, description, syntax, parameters, or return values. For example, you might explain non-obvious context, make a comparison to similar elements, or provide cautionary notes about potential gotchas. |
 
 Additional tips:
+
 - Remember to write concisely. Don't say "This method adds a user." when "Adds a user." will do. If your linter requires the description to begin with the element name, you may say "The AddUser method adds a user." to avoid an error message.
-- When the names of code elements are singular, don't make them plural. Instead, add a plural noun to describe them. For example, don't change `MyEvent` to `MyEvents`; refer to the `MyEvent` objects. 
-- If the element does some sort of action, start the first sentence of the description with an action verb. 
+- When the names of code elements are singular, don't make them plural. Instead, add a plural noun to describe them. For example, don't change `MyEvent` to `MyEvents`; refer to the `MyEvent` objects.
+- If the element does some sort of action, start the first sentence of the description with an action verb.
 
 ## Code examples
 
 Readers of documentation typically skim through it to find code samples they can copy and paste and run as is.
 Because of this and whenever possible, provide production-ready examples.
 
-However, it isn't necessary for every code example to be runnable in production.  Some code examples are written to illustrate a point so that the developer can learn how to do something similar on their own.
+However, it isn't necessary for every code example to be runnable in production. Some code examples are written to illustrate a point so that the developer can learn how to do something similar on their own.
 
 When providing an example, give a written description. You can put it either in the body of the document or as explanatory comments within the example code.
 
@@ -86,12 +86,12 @@ For an in-depth, external resource about writing developer documentation, see [_
 
 Here are guidelines to follow when formatting code examples.
 
-- Use spaces, not tabs. 
+- Use spaces, not tabs.
 - Follow Grafana's accepted [coding style guidelines](https://github.com/grafana/grafana/blob/main/contribute/style-guides/).
 - Wrap lines at 80 characters.
 - When omitting code, use three dots (...). Don't use the ellipsis character (…).
 
-Introduce each code sample with a sentence or paragraph to establish its context. End the introduction with a colon if it immediately precedes the sample, or a period if it doesn't. 
+Introduce each code sample with a sentence or paragraph to establish its context. End the introduction with a colon if it immediately precedes the sample, or a period if it doesn't.
 
 ### Paths, filenames, and URLs
 
@@ -126,7 +126,7 @@ It produces:
 sudo yum install grafana
 ```
 
-If your command-line instructions include a combination of input and output lines, use separate code blocks for input and output, and use a `console` code block for the output. 
+If your command-line instructions include a combination of input and output lines, use separate code blocks for input and output, and use a `console` code block for the output.
 
 The input, in raw markdown:
 
@@ -165,16 +165,16 @@ Authorization: Bearer  eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 If an argument is optional, enclose it in square brackets. For example, prefer the following raw markdown:
 
 ````
-```typescript 
+```typescript
 ssh-rsa KEY_VALUE USERNAME [_FILENAME_]
 ```
 ````
 
 It produces:
 
- ```typescript
- ssh-rsa KEY_VALUE USERNAME [_FILENAME_]
- ```
+```typescript
+ssh-rsa KEY_VALUE USERNAME [_FILENAME_]
+```
 
 Use descriptive words and phrases when including placeholders, and avoid using X or XXX.
 In Markdown, in front of a placeholder, use an asterisk followed by a backtick. At the end of the placeholder, use a backtick followed by an asterisk. For example, prefer the following raw markdown:

--- a/docs/sources/writing-guide/_index.md
+++ b/docs/sources/writing-guide/_index.md
@@ -2,8 +2,6 @@
 title: Writing guide
 menuTitle: Writing guide
 description: Learn about Grafana Labs' technical documentation writing guidelines.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/
 weight: 200
 Keywords:
   - writing
@@ -17,7 +15,9 @@ The writing guide defines the structured authoring environment we use to create 
 The guidelines are for anyone who is interested in improving Grafana Labs' technical content. They are intended to guide you on your documentation journey, whether you are requesting a change, editing a topic, or writing a set of documentation for a new product or feature from scratch.
 
 If you are already familiar with the guidelines, feel free to get started from one of the [templates](https://github.com/grafana/writers-toolkit/tree/main/docs/static/templates).
-<!-- vale Grafana.Exclamation = NO -->
-We hope you find what you are looking for. If you don't, provide us with the feedback, so we can continuously improve this writing guide.
-<!-- vale Grafana.Exclamation = YES -->
 
+<!-- vale Grafana.Exclamation = NO -->
+
+We hope you find what you are looking for. If you don't, provide us with the feedback, so we can continuously improve this writing guide.
+
+<!-- vale Grafana.Exclamation = YES -->

--- a/docs/sources/writing-guide/about-grafana-docs/index.md
+++ b/docs/sources/writing-guide/about-grafana-docs/index.md
@@ -2,8 +2,6 @@
 title: Introduction to documentation
 menuTitle: Introduction to documentation
 description: Learn about Grafana's documentation
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/about-grafana-docs/
 weight: 100
 keywords:
   - Grafana
@@ -36,7 +34,7 @@ Why is topic-based authoring important?
 - **Writing that isn’t topic-based is difficult for readers to understand.** Content, structure, terminology, and writing style differs and can confuse and frustrate readers.
 
 - **Writing that is topic-based is more consistent and user-friendly.**
-Users can find the information they are looking for quickly and easily. It has a more consistent format and voice, clearly defining the Grafana brand.
+  Users can find the information they are looking for quickly and easily. It has a more consistent format and voice, clearly defining the Grafana brand.
 
 ## Markdown
 

--- a/docs/sources/writing-guide/contribute-documentation/index.md
+++ b/docs/sources/writing-guide/contribute-documentation/index.md
@@ -2,8 +2,6 @@
 title: Contribute to documentation
 menuTitle: Contribute to documentation
 description: This section describes the different ways of contributing to documentation.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/contribute-documentation/
 weight: 200
 keywords:
   - contribute

--- a/docs/sources/writing-guide/contribute-release-notes/index.md
+++ b/docs/sources/writing-guide/contribute-release-notes/index.md
@@ -2,8 +2,6 @@
 title: Contribute to What's New or release notes
 menuTitle: Contribute to What's New or release notes
 description: This section describes the different ways of contributing to the What's New document or release notes.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/contribute-release-notes/
 weight: 250
 keywords:
   - what's new
@@ -18,7 +16,7 @@ This topic explains the decisions and actions associated with collecting, writin
 
 ## What's New doc development process
 
-Developing directly in Markdown reduces errors and removes a manual (toilsome and error-prone step), by creating, editing, discussing, and publishing in the same format from which we will publish in GitHub, using the Grafana repo. 
+Developing directly in Markdown reduces errors and removes a manual (toilsome and error-prone step), by creating, editing, discussing, and publishing in the same format from which we will publish in GitHub, using the Grafana repo.
 
 Consider adding an image, though be aware that we will not maintain them, as the document reflects a "point in time." If you need to add an image, refer to [Image, diagram, and screenshot guidelines]({{< relref "../image-guidelines/" >}}).
 
@@ -27,15 +25,15 @@ Consider adding an image, though be aware that we will not maintain them, as the
 Complete the following steps within one week after the prior release goes out.
 
 1. The Docs Squad identifies the technical writer responsible for overseeing the What’s New content development process for the upcoming release.
-1. The identified technical writer cuts a branch and creates a draft PR with an empty What's New doc to be populated with the What’s New content for the next release, along with the updated What's New index page. 
+1. The identified technical writer cuts a branch and creates a draft PR with an empty What's New doc to be populated with the What’s New content for the next release, along with the updated What's New index page.
    - This PR should include an update to the link and version number located on the What's New tile of `docs/sources/_index.md`.
    - This PR should include the new Upgrade Guide page (process TBA).
    - This PR should not have a `backport` label initially.
 1. The technical writer then pins a link to the [version-number-release-gtm](https://raintank-corp.slack.com/archives/C02L8GQJGBW) Slack channel.
 
-   > **Note:** A Product Manager (PM) is responsible for updating the version number of that channel after a release goes out. 
-   
-1. The technical writer posts in the Slack channel that the What's New PR is ready for contributions. 
+   > **Note:** A Product Manager (PM) is responsible for updating the version number of that channel after a release goes out.
+
+1. The technical writer posts in the Slack channel that the What's New PR is ready for contributions.
 1. The PM or PMM on point communicates with engineering squads without a PM resource about who’s on point for What’s New PR reviews from within the PM and PMM orgs.
 
    Refer to [Grafana Releases and Release Dates](https://grafana-intranet--simpplr.visualforce.com/apex/simpplr__app?u=/site/a145f000001dCXBAA2/page/a125f000001AXrwAAG) for a list of release dates and go-to-market coordinators.
@@ -59,6 +57,7 @@ At this point, the larger Marketing org can review the What’s New content in t
 Complete the following steps in the days leading up to the release:
 
 1. Five days before the GA release:
+
    - The PM or PMM running the release sends a **Last Call** to dev teams to get in their What’s New content.
    - The technical writer changes the PR status from **Draft** to **Ready for Review**.
 
@@ -74,7 +73,7 @@ Complete the following steps in the days leading up to the release:
 
 ## How to determine if content belongs in a What's New document
 
-Grafana publishes a What’s New [docs page](/docs/grafana/latest/whatsnew/) and [blog post](/blog/2022/11/29/grafana-9.3-release/) along with every minor and major release. These posts are popular, and a good way for users to learn about the exciting new things we’ve released. What’s New also drives our go-to-market enablement: we train the field and make videos on the topics in What’s New. 
+Grafana publishes a What’s New [docs page](/docs/grafana/latest/whatsnew/) and [blog post](/blog/2022/11/29/grafana-9.3-release/) along with every minor and major release. These posts are popular, and a good way for users to learn about the exciting new things we’ve released. What’s New also drives our go-to-market enablement: we train the field and make videos on the topics in What’s New.
 
 However, unlike our comprehensive changelog, What’s New is curated. If it contained every update, it would be too noisy for people to read, and if we wrote a detailed What’s New post for every little bug fix, we’d be wasting our time.
 
@@ -85,7 +84,7 @@ So how do you decide whether to write a What’s New post for your latest improv
 What's new content should address changes that have some kind of material impact on the user experience.
 
 - Include changes that _affect customers_, whether they are new features to try out or important, long-requested bug fixes.
-  - Most visualization changes and most additions to the UI should be in the What's new document, even when they seem small. 
+  - Most visualization changes and most additions to the UI should be in the What's new document, even when they seem small.
 - Almost every change or addition associated with Prometheus and Loki is of interest, too.
 - What's New content should also include changes that require customers to do something, like change their API keys to Service Accounts, or stop using a deprecated API or plugin.
 - A What's New doc should include announcements — things we want customers to notice and try out. These could also be notable community contributions where we want to thank a contributor.
@@ -98,9 +97,9 @@ When in doubt, ask your nearest PM or EM. Err on the side of _yes, put it in Wha
   - This is one of many transformations, but it is brand-new functionality that a user might not notice if they didn’t read the What's New document. What’s New is also a low-effort place to describe some nice use cases and examples for the feature so that users adopt it.
 - The new [Candlestick visualization](/docs/grafana/latest/whatsnew/whats-new-in-v8-3/#candlestick-panel-beta).
   - This was a beta feature, but still listed in What’s new in order to get the word out and encourage users to try it.
-- All-new Swagger docs for the API. 
+- All-new Swagger docs for the API.
   - This is significant because it makes our documentation much easier to use, and it’s a new place for users to go for help when using our API.
-- [Removing beta labels from several panels](https://github.com/grafana/grafana/pull/58557), which makes then generally available. 
+- [Removing beta labels from several panels](https://github.com/grafana/grafana/pull/58557), which makes then generally available.
   - This is a small change code-wise, but a big statement with big customer impact. Customers now know that those plugins are fully supported and recommended for use in production.
 - [New keyboard shortcut](https://github.com/grafana/grafana/pull/61837)
   - This is a small change, but it brings attention to a feature that has been improved recently and that most people don't know about.
@@ -109,7 +108,7 @@ When in doubt, ask your nearest PM or EM. Err on the side of _yes, put it in Wha
 - [Changes to the Prometheus query editor](https://github.com/grafana/grafana/pull/60718)
   - These are query patterns for the data source that most of our users use.
 
-### Examples of what *not* to include in What’s New
+### Examples of what _not_ to include in What’s New
 
 These are important improvements, but are better placed in the changelog than What’s new:
 
@@ -128,15 +127,15 @@ Follow these guidelines to ensure that your What's New or release notes content 
 
 - **Directly address your users.**
 
-    Address them using the imperative or as “you”.
+  Address them using the imperative or as “you”.
 
-    **Example:**
-    Shorten your communication time when reporting issues and requesting help from Grafana Labs by grabbing a panel’s query response data and panel settings.
+  **Example:**
+  Shorten your communication time when reporting issues and requesting help from Grafana Labs by grabbing a panel’s query response data and panel settings.
 
 - **Make use of active voice or present tense.**
 
-    **Example:**
-    Enable a configuration option to skip user organization and roles synchronization with your SAML provider.
+  **Example:**
+  Enable a configuration option to skip user organization and roles synchronization with your SAML provider.
 
 - **Don't refer to the release version, for example, “In Grafana 9, we ” or “As of now, we”.**
 

--- a/docs/sources/writing-guide/documentation-structure/index.md
+++ b/docs/sources/writing-guide/documentation-structure/index.md
@@ -1,8 +1,6 @@
 ---
 title: Documentation structure
 description: How to organize concepts and tasks in the repository.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/documentation-structure/
 weight: 300
 menuTitle: Documentation structure
 keywords:
@@ -47,9 +45,10 @@ For example, a new Grafana user wants to learn conceptual information first, so 
 ### Use the topics you need
 
 Depending on your product design and maturity, you may not need every topic:
-* If a topic does not apply to your project, you don't need to use it.
-* For Grafana OSS for example, you might use all of the headings.
-* For Grafana Enterprise Traces for example, you might only use a subset of topics.
+
+- If a topic does not apply to your project, you don't need to use it.
+- For Grafana OSS for example, you might use all of the headings.
+- For Grafana Enterprise Traces for example, you might only use a subset of topics.
 
 Some topics are optional and are usually found in specific contexts.
 For example, the _Create_, _Manage_, and _Monitor_ topics are used in Grafana OnCall, but are not used in Grafana Tempo.
@@ -58,25 +57,22 @@ For example, the _Create_, _Manage_, and _Monitor_ topics are used in Grafana On
 
 You can use the following high-level topics to group content. When writing new content, consider where it should appear given this content structure. For example, a conceptual page explaining metrics would go under the _Introduction_ topic.
 
-
-| Topic | Example link | Contents |
-| --- | --- | --- |
-| _Introduction_ | [Introduction to Grafana](/docs/grafana/latest/introduction/) | Conceptual, fundamental, or architectural information.  |
-| _Get started_ | [Get started with Tempo](/docs/tempo/latest/getting-started/) | Opinionated walk-throughs and tutorials. |
-| _Set up_ | [Set up Grafana](/docs/grafana/latest/setup-grafana/) | System requirements, and subsections titled _Set up_, _Configure_, _Upgrade_, or _Migrate_. |
-| _Configure_ | [Configure Grafana Agent](/docs/agent/latest/configuration/) | _Configure_ can be its own section directory if the number of pages warrants it. Making this determination is not an exact science; use your best judgement. |
-| _Create alerts_ | [Create a Grafana managed alert rule](/docs/grafana-cloud/alerting/alerting-rules/create-grafana-managed-rule/) | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). The word _alert_ may be changed, depending upon the product. If used with Grafana SLO, this then topic would be _Create SLO_. Do not use with backend database products, such as Tempo and Loki. Use _Alerts_ instead, and refer to an operational product for details. |
-| _Manage alerts_ | [Manage and monitor SLOs](/docs/grafana-cloud/slo/manage/) | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). Do not use with backend database products, such as Tempo and Loki. Use _Alert_ instead, and refer to an operational product for details. |
-| _Monitor alerts_ | [Meta monitoring](/docs/grafana/next/alerting/meta-monitoring/) | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). Do not use with backend database products, such as Tempo and Loki. Use _Alert_ instead, and refer to an operational product for details.  |
-| _Integrate (with) [product]_ or _Send data_ | [Connect your data to Grafana Cloud](/docs/grafana-cloud/data-configuration/get-started-data/) | How to set up data integrations, product integrations, data sources, clients, plugins, and more. |
-| _Query data_ | [TraceQL](/docs/tempo/latest/traceql/) | Query languages, query tools, and examples. |
-| _Visualize data_ | [Dashboards](/docs/grafana/latest/dashboards/) | Dashboard concepts and procedures. Link to the definitive source of dashboard documentation, rather than duplicating the information here. |
-| _Alert_ | [Alerting rules](/docs/loki/latest/rules/) | This topic level is used for pages that discuss alerting features, like Grafana Loki's alerting rules. It provides a place for alerting content that is not specific to the Grafana Operations products. |
-| _Manage [product]_ | [Manage users and teams with Grafana Oncall](/docs/grafana-cloud/oncall/configure-user-settings/) | Information about managing a Grafana Labs product. For example, content in this topic helps you view, edit, and iterate on the Grafana product you installed. |
-| _Monitor [product]_ | [Monitor Mimir](/docs/mimir/latest/operators-guide/monitor-grafana-mimir/) | Information about using tools to monitor a Grafana Labs product. |
-| _References_ | [HTTP API reference](/docs/grafana-cloud/api-reference/http-api/) | APIs, configuration references, SDKs, and more. Material that is usually not procedural. |
-
-
+| Topic                                       | Example link                                                                                                    | Contents                                                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Introduction_                              | [Introduction to Grafana](/docs/grafana/latest/introduction/)                                                   | Conceptual, fundamental, or architectural information.                                                                                                                                                                                                                                                                                       |
+| _Get started_                               | [Get started with Tempo](/docs/tempo/latest/getting-started/)                                                   | Opinionated walk-throughs and tutorials.                                                                                                                                                                                                                                                                                                     |
+| _Set up_                                    | [Set up Grafana](/docs/grafana/latest/setup-grafana/)                                                           | System requirements, and subsections titled _Set up_, _Configure_, _Upgrade_, or _Migrate_.                                                                                                                                                                                                                                                  |
+| _Configure_                                 | [Configure Grafana Agent](/docs/agent/latest/configuration/)                                                    | _Configure_ can be its own section directory if the number of pages warrants it. Making this determination is not an exact science; use your best judgement.                                                                                                                                                                                 |
+| _Create alerts_                             | [Create a Grafana managed alert rule](/docs/grafana-cloud/alerting/alerting-rules/create-grafana-managed-rule/) | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). The word _alert_ may be changed, depending upon the product. If used with Grafana SLO, this then topic would be _Create SLO_. Do not use with backend database products, such as Tempo and Loki. Use _Alerts_ instead, and refer to an operational product for details. |
+| _Manage alerts_                             | [Manage and monitor SLOs](/docs/grafana-cloud/slo/manage/)                                                      | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). Do not use with backend database products, such as Tempo and Loki. Use _Alert_ instead, and refer to an operational product for details.                                                                                                                                |
+| _Monitor alerts_                            | [Meta monitoring](/docs/grafana/next/alerting/meta-monitoring/)                                                 | Specific to Grafana Ops products (Alerting, OnCall, Incident, SLOs). Do not use with backend database products, such as Tempo and Loki. Use _Alert_ instead, and refer to an operational product for details.                                                                                                                                |
+| _Integrate (with) [product]_ or _Send data_ | [Connect your data to Grafana Cloud](/docs/grafana-cloud/data-configuration/get-started-data/)                  | How to set up data integrations, product integrations, data sources, clients, plugins, and more.                                                                                                                                                                                                                                             |
+| _Query data_                                | [TraceQL](/docs/tempo/latest/traceql/)                                                                          | Query languages, query tools, and examples.                                                                                                                                                                                                                                                                                                  |
+| _Visualize data_                            | [Dashboards](/docs/grafana/latest/dashboards/)                                                                  | Dashboard concepts and procedures. Link to the definitive source of dashboard documentation, rather than duplicating the information here.                                                                                                                                                                                                   |
+| _Alert_                                     | [Alerting rules](/docs/loki/latest/rules/)                                                                      | This topic level is used for pages that discuss alerting features, like Grafana Loki's alerting rules. It provides a place for alerting content that is not specific to the Grafana Operations products.                                                                                                                                     |
+| _Manage [product]_                          | [Manage users and teams with Grafana Oncall](/docs/grafana-cloud/oncall/configure-user-settings/)               | Information about managing a Grafana Labs product. For example, content in this topic helps you view, edit, and iterate on the Grafana product you installed.                                                                                                                                                                                |
+| _Monitor [product]_                         | [Monitor Mimir](/docs/mimir/latest/operators-guide/monitor-grafana-mimir/)                                      | Information about using tools to monitor a Grafana Labs product.                                                                                                                                                                                                                                                                             |
+| _References_                                | [HTTP API reference](/docs/grafana-cloud/api-reference/http-api/)                                               | APIs, configuration references, SDKs, and more. Material that is usually not procedural.                                                                                                                                                                                                                                                     |
 
 ## Table of contents levels
 
@@ -111,6 +107,7 @@ For more information about how to write tasks, refer to [Tasks]({{< relref "../t
 ## Pages and page bundles
 
 Each web page generated by Hugo comes from one of three source files:
+
 - `page/_index.md`: a Hugo branch bundle
 - `page/index.md`: a Hugo leaf bundle
 - `page.md`: a Hugo page

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -2,8 +2,6 @@
 title: Front matter
 menuTitle: Front matter
 description: Learn about how we build front matter to properly enable the publication and search of our technical documentation.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/front-matter/
 weight: 700
 keywords:
   - front matter

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -196,12 +196,18 @@ For more detail about HTML redirects, refer to [HTML redirections](https://devel
 
 The correct way to use aliases depends on whether the project is versioned or not.
 
-**Unversioned projects**
-: Include an `aliases` entry that refers to the initial published website directory.
+#### Unversioned projects
+
+Include an `aliases` entry that refers to the initial published website directory.
 Adding an `aliases` entry makes it safer to move content around as the redirect from old to new page location is already in place.
 Hugo doesn't create a redirect `.html` file when the directory is already populated with content.
-: > **Note:** The published directory is dependent on which `content` subdirectory documentation is synced to in the website repository.
-: > For example, documentation synced to a the `content/docs` directory requires the `/docs` prefix.
+Aliases can be relative or absolute paths.
 
-**Versioned projects**
-: Do not include an `aliases` entry that refers to the initial published website directory. The version in the URL path can cause undesirable redirects, such as a redirect from latest content to an old version.
+> **Note:** The published directory is dependent on which `content` subdirectory documentation is synced to in the website repository.
+> For example, documentation synced to a the `content/docs` directory requires the `/docs` prefix.
+
+#### Versioned projects
+
+Do not include an `aliases` entry that refers to the initial published website directory.
+The version in the URL path can cause undesirable redirects, such as a redirect from latest content to an old version.
+Aliases should be relative and not absolute paths so that old versions do not steal redirects from "latest" content when it is moved around.

--- a/docs/sources/writing-guide/image-guidelines/index.md
+++ b/docs/sources/writing-guide/image-guidelines/index.md
@@ -2,8 +2,6 @@
 title: Image, diagram, and screenshot guidelines
 menuTitle: Image and media guidelines
 description: How to include images in your documentation.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/image-guidelines/
 weight: 750
 keywords:
   - image
@@ -26,31 +24,32 @@ However, because translation services and tools for the visually impaired don't 
 
 Consider using images or diagrams when you need to:
 
--  Clarify configurations and settings, such as the architecture for virtual servers
--  Define a complex workflow within a Grafana product
+- Clarify configurations and settings, such as the architecture for virtual servers
+- Define a complex workflow within a Grafana product
 
-Do *not* include images or diagrams when:
+Do _not_ include images or diagrams when:
 
--  A workflow is simplistic
--  There is no interaction with a Grafana product
+- A workflow is simplistic
+- There is no interaction with a Grafana product
 
 ### Image and diagram standards
 
 Use the following standards for images and diagrams:
 
--  **Size**: To reduce page-load time, make images and diagrams as small as you can without compromising their usefulness.
-Unless image clarity is critical to understanding, use 65-75 percent quality when saving your image.
-Use the following recommendations when you size images:
-   -  Horizontal: maximum width 1200px
-   -  Vertical: maximum height 900px
+- **Size**: To reduce page-load time, make images and diagrams as small as you can without compromising their usefulness.
+  Unless image clarity is critical to understanding, use 65-75 percent quality when saving your image.
+  Use the following recommendations when you size images:
 
--  **Scope**: Limit the contents of an image to the relevant portion.
-Do not include distracting or unnecessary content and whitespace.
--  **Format**: **png** and **svg** are the preferred image formats. Use **jpg** only for photos.
--  **Copyright**: Determine if an image or diagram is protected by copyright.
-If it is, you must obtain permission and acknowledge credit.
--  **File name**: Use the naming convention documented in [Media asset file naming conventions](#media-asset-file-naming-conventions).
--  **Personal identifiable information (PII)**: Make sure to mask, modify, or remove any PII such as passwords, logins, account details, or other information that could compromise security.
+  - Horizontal: maximum width 1200px
+  - Vertical: maximum height 900px
+
+- **Scope**: Limit the contents of an image to the relevant portion.
+  Do not include distracting or unnecessary content and whitespace.
+- **Format**: **png** and **svg** are the preferred image formats. Use **jpg** only for photos.
+- **Copyright**: Determine if an image or diagram is protected by copyright.
+  If it is, you must obtain permission and acknowledge credit.
+- **File name**: Use the naming convention documented in [Media asset file naming conventions](#media-asset-file-naming-conventions).
+- **Personal identifiable information (PII)**: Make sure to mask, modify, or remove any PII such as passwords, logins, account details, or other information that could compromise security.
 
 ### Diagram assets
 
@@ -73,25 +72,25 @@ As a result, you should minimize the use of screenshots within your content.
 
 Consider using screenshots when you want to:
 
--  Provide an example of a visualization
--  Show panels populated with a query and settings
--  Orient users in a complicated or long procedure
--  Show complex relationships among drop-down menus, such as those that contain multiple subsets of information and many options available for selection
--  Emphasize a new feature or a change in the UI
+- Provide an example of a visualization
+- Show panels populated with a query and settings
+- Orient users in a complicated or long procedure
+- Show complex relationships among drop-down menus, such as those that contain multiple subsets of information and many options available for selection
+- Emphasize a new feature or a change in the UI
 
 ### When not to use screenshots
 
-*Do not* use screenshots for the following items:
+_Do not_ use screenshots for the following items:
 
--  Simple create operations, such as create a user, a team, an organization, and so on
--  Primary or secondary navigation items
--  Code samples (show code samples in code blocks)
--  Dialog boxes that are easy to understand
--  Message text (instead show message text within the Markdown)
--  Progress bars
--  Simple pages, such as Wizard pages and Welcome pages
--  Tables created in another authoring tool
--  A page that is likely to change frequently
+- Simple create operations, such as create a user, a team, an organization, and so on
+- Primary or secondary navigation items
+- Code samples (show code samples in code blocks)
+- Dialog boxes that are easy to understand
+- Message text (instead show message text within the Markdown)
+- Progress bars
+- Simple pages, such as Wizard pages and Welcome pages
+- Tables created in another authoring tool
+- A page that is likely to change frequently
 
 ### Screenshot alternatives
 
@@ -111,82 +110,83 @@ However, ensure that the screenshot accurately reflects the directions and value
 
 Consult the following guidelines when you create screenshots:
 
--  **Size**: The maximum width of a screenshot is 600 pixels.
--  **Scope**: Limit the screenshot to just the portion of the user interface that shows the action, and enough surrounding detail to help the user locate the item.
--  **Annotations**: To annotate a screenshot, use red (hexadecimal color **FF0000**) arrows and boxes.
--  **File name**: Use the naming convention documented in [Media asset file naming conventions](#media-asset-file-naming-conventions).
--  **Personal identifiable information (PII)**: Make sure to mask, modify, or remove any PII such as passwords, logins, account details, or other information that could compromise security.
+- **Size**: The maximum width of a screenshot is 600 pixels.
+- **Scope**: Limit the screenshot to just the portion of the user interface that shows the action, and enough surrounding detail to help the user locate the item.
+- **Annotations**: To annotate a screenshot, use red (hexadecimal color **FF0000**) arrows and boxes.
+- **File name**: Use the naming convention documented in [Media asset file naming conventions](#media-asset-file-naming-conventions).
+- **Personal identifiable information (PII)**: Make sure to mask, modify, or remove any PII such as passwords, logins, account details, or other information that could compromise security.
 
 ## Media asset file naming conventions
 
 The table in this section includes file naming conventions for you to follow when you create image assets.
 
 General rules:
+
 - Use lowercase letters in filenames, always.
 - Use dashes between words; do not use spaces or underscores.
 - Do not type special characters or punctuation marks in a file name except for periods in product version numbers (for example, `grafana-9.2.release.png`.
 - Don’t use abbreviations that will cause issues with localization.
   - For example, spell out `database` instead of using `db`, but using an acronym, such as RBAC, is ok.
   - When in doubt, don’t use an abbreviation.
-<table>
-    <thead>
-        <tr>
-            <th>Asset type</th>
-            <th>Naming convention</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td align="left" valign="top">Screenshot</td>
-            <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description]-[version, if applicable].png <br><br><b>Examples:</b><br>
-<ul><li>screenshot-grafana-loki-uptime-dashboard.png</li>
-<li>screenshot-grafana-mimir-data-flow-diagram.png</li>
-<li>screenshot-grafana-9-kubernetes-dashboard.png (or)</li>
-<li>screenshot-grafana-9.0-kubernetes-dashboard.png</li>
-<li>screenshot-simple-scalable-test-environment-grafana-loki.png</li>
-</ul>
-</td>
-        </tr>
-        <tr>
-            <td align="left" valign="top">Icon</td>
-            <td align="left" valign="top">Be as descriptive as possible.<br><br>
-            For example, use `icon-bar-graph.svg` or `icon-graph-bar.svg` instead of `icon-graph.svg`.<br>
-            <b>Naming convention:</b> [asset type]-[visual description].svg<br><br>
-            <b>Examples:</b>
-<ul><li>icon-bar-graph.svg</li>
-<li>icon-prometheus.svg</li>
-</ul>
-        </tr>
-        <tr>
-            <td align="left" valign="top">Logo</td>
-            <td align="left" valign="top">When you name Grafana logo files, be sure to include the word “grafana”.<br><br>
-            <b>Naming convention:</b> [asset type]-[visual description]-[color + orientation].[file type]
-<br><br>
-            <b>Examples:</b>
-<ul><li>logo-prometheus-full-horizontal.svg</li>
-<li>logo-grafana-loki-full-horizontal.svg</li>
-</ul>
-        </tr>
-       <tr>
-            <td align="left" valign="top">Photo</td>
-            <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description].jpg
-<br><br>
-            <b>Examples:</b>
-<ul><li>photo-raji-on-stage-grafanacon-keynote-2022.jpg</li>
-<li>photo-grafanacon-team-marketing.jpg</li>
-<li>photo-headshot-mike-szczys.jpg</li>
-</ul>
-        </tr>
-        <tr>
-            <td align="left" valign="top">Recording</td>
-            <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description].[file type]
-<br><br>
-            <b>Example:</b>
-<ul><li>gif-grafana-share-playlist.mp4</li>
-</ul>
-        </tr>
-    </tbody>
-</table>
+  <table>
+      <thead>
+          <tr>
+              <th>Asset type</th>
+              <th>Naming convention</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td align="left" valign="top">Screenshot</td>
+              <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description]-[version, if applicable].png <br><br><b>Examples:</b><br>
+  <ul><li>screenshot-grafana-loki-uptime-dashboard.png</li>
+  <li>screenshot-grafana-mimir-data-flow-diagram.png</li>
+  <li>screenshot-grafana-9-kubernetes-dashboard.png (or)</li>
+  <li>screenshot-grafana-9.0-kubernetes-dashboard.png</li>
+  <li>screenshot-simple-scalable-test-environment-grafana-loki.png</li>
+  </ul>
+  </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top">Icon</td>
+              <td align="left" valign="top">Be as descriptive as possible.<br><br>
+              For example, use `icon-bar-graph.svg` or `icon-graph-bar.svg` instead of `icon-graph.svg`.<br>
+              <b>Naming convention:</b> [asset type]-[visual description].svg<br><br>
+              <b>Examples:</b>
+  <ul><li>icon-bar-graph.svg</li>
+  <li>icon-prometheus.svg</li>
+  </ul>
+          </tr>
+          <tr>
+              <td align="left" valign="top">Logo</td>
+              <td align="left" valign="top">When you name Grafana logo files, be sure to include the word “grafana”.<br><br>
+              <b>Naming convention:</b> [asset type]-[visual description]-[color + orientation].[file type]
+  <br><br>
+              <b>Examples:</b>
+  <ul><li>logo-prometheus-full-horizontal.svg</li>
+  <li>logo-grafana-loki-full-horizontal.svg</li>
+  </ul>
+          </tr>
+         <tr>
+              <td align="left" valign="top">Photo</td>
+              <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description].jpg
+  <br><br>
+              <b>Examples:</b>
+  <ul><li>photo-raji-on-stage-grafanacon-keynote-2022.jpg</li>
+  <li>photo-grafanacon-team-marketing.jpg</li>
+  <li>photo-headshot-mike-szczys.jpg</li>
+  </ul>
+          </tr>
+          <tr>
+              <td align="left" valign="top">Recording</td>
+              <td align="left" valign="top"><b>Naming convention:</b> [asset type]-[visual description].[file type]
+  <br><br>
+              <b>Example:</b>
+  <ul><li>gif-grafana-share-playlist.mp4</li>
+  </ul>
+          </tr>
+      </tbody>
+  </table>
 
 ### Recommended image editors
 
@@ -196,6 +196,7 @@ General rules:
 - Web browser: Use [Photopea](https://www.photopea.com/)
 
 ## Where to store media assets
+
 All visual assets are stored in Google Cloud Storage, only accessible to Grafana Labs employees. You use the [asset uploader application](https://admin.grafana.com/upload/) to upload assets.
 The following table lists the steps you take to provide the Grafana Labs technical documentation team with the image.
 
@@ -240,12 +241,14 @@ We do not expect you to test that the image renders in a local build of the help
 </table>
 
 ## Add an image to a Markdown file
+
 To add an image to a Markdown file, insert a reference to the image below the associated step and indent it so that the reference aligns with the step text.
 
 The image reference path conforms to the following convention:
 `![<Short description of image>](/media/<path-to-image/image-file.png>)`
 
 For example:
+
 1. In the Visualization list, select a visualization type.
 
    `![Visualization types](/media/docs/panel-editor/select-visualization.png)`
@@ -260,7 +263,6 @@ It is important that you generate a local build of your docs so that you can ver
 
 1. Run `make docs` on your branch and verify that the image appears.
 1. (Optional) Upload a new version and test again.
-
 
 ## Screen recordings
 

--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -2,8 +2,6 @@
 title: Markdown guide
 menuTitle: Markdown guide
 description: Guidelines for writing technical documentation in Markdown.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/markdown-guide/
 weight: 500
 keywords:
   - Markdown
@@ -28,7 +26,7 @@ Hugo uses a Markdown parser named Goldmark, which supports the CommonMark flavor
 
 ## Headings
 
-Similar to HTML headings (`<h1>`, `<h2>`, and `<h3>`), in Markdown, `#` symbols (or *hash tags*) create different heading levels:
+Similar to HTML headings (`<h1>`, `<h2>`, and `<h3>`), in Markdown, `#` symbols (or _hash tags_) create different heading levels:
 
 **Example**
 
@@ -55,7 +53,7 @@ For the title of the page, use one `#`. For each child heading, use two `##` sym
   > **Note:** It is important to use GitHub-flavored Markdown emojis consistently.
 
 - To emphasize text, surround the text with `_single underscores_`̣.
-Do not use single asterisks (`*`), because they can be easily confused with two (for bold).
+  Do not use single asterisks (`*`), because they can be easily confused with two (for bold).
 
 ```markdown
 **Note:** The distributor only passes _valid_ data to the ingesters.
@@ -75,7 +73,7 @@ If you want to add a link to an external website, wrap the display text in squar
 [Link text to display](https://example.com)
 ```
 
-**Example:** For more information about including emojis in GitHub-flavored Markdown, refer to the WebFX [Emoji Cheat Sheet](https://www.webfx.com/tools/emoji-cheat-sheet/). 
+**Example:** For more information about including emojis in GitHub-flavored Markdown, refer to the WebFX [Emoji Cheat Sheet](https://www.webfx.com/tools/emoji-cheat-sheet/).
 
 ## Block quotes
 
@@ -97,9 +95,9 @@ Code blocks within Markdown can highlight syntax that is specific to a language.
 ```javascript
 function testNum(a) {
   if (a > 0) {
-    return 'positive';
+    return "positive";
   } else {
-    return 'NOT positive';
+    return "NOT positive";
   }
 }
 ```
@@ -112,7 +110,7 @@ Construct a table by separating the table headings by a `|` (pipe) character. Th
 
 ```markdown
 | Heading one   | Heading two   |
-| ------------  | ------------  |
+| ------------- | ------------- |
 | Cell one data | Cell two data |
 ```
 
@@ -176,9 +174,11 @@ This follows the format `![alt text](URL)`.
 Within Markdown, HTML is valid and to be used sparingly:
 
 ```html
-<img src="example.png"
-     alt="Example image"
-     style="float: left; margin-right: 5px;" />
+<img
+  src="example.png"
+  alt="Example image"
+  style="float: left; margin-right: 5px;"
+/>
 ```
 
 In most cases, use Markdown syntax rather than HTML syntax. Only use HTML if you need to change the image in ways that Markdown does not support.
@@ -205,7 +205,6 @@ Reasons you might want to write programs in Go include the following:
 
 **Ecosystem**
 : Go tooling is excellent.
-
 ```
 
 The preceding description list displays as follows:
@@ -225,4 +224,3 @@ You can include comments that do not display in published output:
 ## Shortcodes
 
 Shortcodes are predefined templates that let you reuse snippets of technical documentation. To learn how to use shortcodes, refer to [Shortcodes]({{< relref "../shortcodes/" >}}).
-

--- a/docs/sources/writing-guide/references/index.md
+++ b/docs/sources/writing-guide/references/index.md
@@ -2,8 +2,6 @@
 title: Links and cross references
 menuTitle: Links and cross references
 description: Understand how Hugo determines references, the different types of references, and how to use them.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/references/
 weight: 600
 keywords:
   - Hugo

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -2,8 +2,6 @@
 title: Shortcodes
 menuTitle: Shortcodes
 description: Understand what shortcodes are and how to use them in your Markdown.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/shortcodes/
 weight: 800
 keywords:
   - Hugo

--- a/docs/sources/writing-guide/tooling-and-workflows/_index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/_index.md
@@ -2,8 +2,6 @@
 title: Documentation tooling and workflows
 menuTitle: Documentation tooling and workflows
 description: How to use documentation tools and understand our workflows.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/tooling-and-workflows/
 weight: 800
 keywords:
   - git
@@ -309,4 +307,3 @@ Automatic merge failed; fix conflicts and then commit the result.
 
 GitHub also has detailed, cross-platform instructions for resolving a merge conflict using git on the command line.
 See [its documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line) for details.
-

--- a/docs/sources/writing-guide/tooling-and-workflows/backporting/index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/backporting/index.md
@@ -2,8 +2,6 @@
 title: Backporting
 menuTitle: Backporting
 description: How and when to backport.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/backporting/
 weight: 100
 keywords:
   - backporting

--- a/docs/sources/writing-guide/topic-types/_index.md
+++ b/docs/sources/writing-guide/topic-types/_index.md
@@ -2,8 +2,6 @@
 title: Topic types
 menuTitle: Topic types
 description: Learn to write different types of topics.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/topic-types/
 weight: 400
 keywords:
   - topic types
@@ -24,6 +22,6 @@ Depending on the needs of a particular product area, select a topic type from th
 | [Concept]({{< relref "concept/" >}})     | Provides an overview and background information. Answers the question "What is it?".                                                                   |
 | [Task]({{< relref "task/" >}})           | Provides numbered steps that describe how to achieve an outcome. Answers the question "How do I?".                                                     |
 | [Reference]({{< relref "reference/" >}}) | Provides users with the information they might need to refer to during a task. Answers the question "What details do I need to accomplish this task?". |
-| [Tutorial]({{< relref "tutorial/" >}}) | Provides procedures that users can safely reproduce and learn from. Answers the question: "Can you teach me to …?" |
+| [Tutorial]({{< relref "tutorial/" >}})   | Provides procedures that users can safely reproduce and learn from. Answers the question: "Can you teach me to …?"                                     |
 
 For your convenience, we have created topic [templates](https://github.com/grafana/writers-toolkit/tree/main/docs/static/templates).

--- a/docs/sources/writing-guide/topic-types/concept/index.md
+++ b/docs/sources/writing-guide/topic-types/concept/index.md
@@ -2,8 +2,6 @@
 title: Concept topic
 menuTitle: Concept
 description: Learn how to write a concept topic.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/topic-types/concept/
 weight: 100
 keywords:
   - topic types

--- a/docs/sources/writing-guide/topic-types/reference/index.md
+++ b/docs/sources/writing-guide/topic-types/reference/index.md
@@ -2,8 +2,6 @@
 title: Reference topic
 menuTitle: Reference
 description: Learn how to write a reference topic.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/topic-types/reference/
 weight: 300
 keywords:
   - topic types
@@ -46,9 +44,11 @@ To write a reference, complete these steps:
    - Add a hyphen between words.
 
      For example:
-      - `calculation-types`
-      - `standard-field-definitions`
-      <p>
+
+     - `calculation-types`
+     - `standard-field-definitions`
+     <p>
+
 1. Create an `index.md` file within the reference directory.
 1. Add front matter to the `index` file.
 

--- a/docs/sources/writing-guide/topic-types/task/index.md
+++ b/docs/sources/writing-guide/topic-types/task/index.md
@@ -2,8 +2,6 @@
 title: Task topic
 menuTitle: Task
 description: Learn how to write a task topic.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/topic-types/task/
 weight: 200
 keywords:
   - topic types
@@ -34,6 +32,7 @@ A _task_ topic includes the following elements:
 **Steps heading**: The steps heading indicates that the steps are about to begin.
 
 **Stem sentence:** The stem sentence introduces the steps. Use the following convention when you write a stem sentence:
+
 - To [name of task], follow these steps:
 - Example: To create a dashboard, follow these steps:
 

--- a/docs/sources/writing-guide/topic-types/tutorial/index.md
+++ b/docs/sources/writing-guide/topic-types/tutorial/index.md
@@ -2,8 +2,6 @@
 title: Tutorial topic
 menuTitle: Tutorial
 description: Learn how to write a tutorial topic.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/topic-types/tutorial/
 weight: 400
 keywords:
   - topic types
@@ -23,28 +21,29 @@ A tutorial topic includes the following elements:
 
 **Topic title:** Write a tutorial topic title that combines a verb and an object.
 
-**Overview:** Let the user know the goal they will achieve by completing the tutorial. Provide context and include a list of the tasks the user will complete. Suggested text: "In this tutorial, you will …". 
+**Overview:** Let the user know the goal they will achieve by completing the tutorial. Provide context and include a list of the tasks the user will complete. Suggested text: "In this tutorial, you will …".
 
 - There can be conceptual material in this section of a tutorial topic. However, limit conceptual information to only what is relevant to the goal at hand.
 - If you find yourself writing a long introduction, consider creating a concept topic, and then writing a shorter form of that concept in the tutorial introduction. The longer concept topic can be accessed for more information by linking to it.
 
 **Before you begin (optional):** Describe or add links to tasks that need to be completed before the tutorial. The links might sometimes be unrelated to the product, such as “Have this thing at hand."
+
 - Additionally, this section can include decisions the user should make or permissions they need to confirm before starting the tutorial.
 - Use a bulleted list if there is more than one prerequisite.
 - If there are no prerequisites, do not include this section.
 
-**Task section (or sections)**: Create a section for each task needed to complete the tutorial. Follow the [task guidelines]({{< relref "../task/" >}}) to write the tasks. 
+**Task section (or sections)**: Create a section for each task needed to complete the tutorial. Follow the [task guidelines]({{< relref "../task/" >}}) to write the tasks.
 
-- To determine what tasks and steps you should include in your tutorial, perform a goal analysis and determine the valuable outcome the user wants to achieve. Limit the tutorial to the tasks needed to satisfy that goal. Work with a Subject Matter Expert (SME) to determine the goal and the minimal set of tasks. If possible, record the SME completing the tasks needed to accomplish the goal or ask the SME to record a demo of the tasks if that's preferable. 
-- Work with a Subject Matter Expert (SME) to 
+- To determine what tasks and steps you should include in your tutorial, perform a goal analysis and determine the valuable outcome the user wants to achieve. Limit the tutorial to the tasks needed to satisfy that goal. Work with a Subject Matter Expert (SME) to determine the goal and the minimal set of tasks. If possible, record the SME completing the tasks needed to accomplish the goal or ask the SME to record a demo of the tasks if that's preferable.
+- Work with a Subject Matter Expert (SME) to
 - Provide steps that explain how to access or set up the data needed to complete the task. See [Data for your tutorial](#data-for-your-tutorial) for details.
 - Do not include written step numbers in the header, for example, "Step 1: Pick apples." Instead, include just the verb and object, for example "Pick apples."
-- Include only the tasks required for a straight path to the tutorial's goal, not optional or alternative paths. 
-- Minimize the explanation within task steps. Instead, link to supporting explanations in related concept, task, and reference topics. 
+- Include only the tasks required for a straight path to the tutorial's goal, not optional or alternative paths.
+- Minimize the explanation within task steps. Instead, link to supporting explanations in related concept, task, and reference topics.
 
-**Summary (optional):** Describe what the tutorial user has accomplished. 
+**Summary (optional):** Describe what the tutorial user has accomplished.
 
-**Next steps (optional):** Provide logical next steps, if they exist.  
+**Next steps (optional):** Provide logical next steps, if they exist.
 
 ![Tutorial structure](tutorial.png)
 
@@ -54,20 +53,18 @@ To write a tutorial, complete these steps:
 
 1. Add a `sources/tutorials` directory to your project repo if one does not yet exist.
 
-    The tutorial is stored in your repo but it is displayed on the Grafana [Tutorials](/tutorials/) page. See [Publish your tutorial](#publish-your-tutorial) for details.
+   The tutorial is stored in your repo but it is displayed on the Grafana [Tutorials](/tutorials/) page. See [Publish your tutorial](#publish-your-tutorial) for details.
 
 1. Create a child directory within the `tutorials` directory that follows this naming convention:
-   
+
    - The directory name should include a verb and an object.
    - Use lowercase letters.
    - Add a hyphen between words.
-  <br>
-  <br>
-   For example:
-     - manage-dashboard-permissions
-     - manage-organization-users
-<br>
-<br>
+     <br>
+     <br>
+     For example: - manage-dashboard-permissions - manage-organization-users
+     <br>
+     <br>
 
 1. Create an `index.md` file within the tutorial's directory.
 1. Add front matter to the `index` file.
@@ -82,25 +79,25 @@ When you are ready to write, make a copy of the [Tutorial template](https://gith
 
 ## Difference between tutorials and task topics
 
-The difference between a tutorial and a task topic is that a tutorial is for learning, and a task is for actual operational work. Another important distinction is that a tutorial typically provides a "sandbox" environment&mdash;a source of data that users can safely experiment with. 
- 
+The difference between a tutorial and a task topic is that a tutorial is for learning, and a task is for actual operational work. Another important distinction is that a tutorial typically provides a "sandbox" environment&mdash;a source of data that users can safely experiment with.
+
 ## Data for your tutorial
- 
+
 Depending on the application, your tutorial's data might be:
 
-  - In a sandbox
-  - On test servers
-  - In demo repos that the user clones locally
- 
+- In a sandbox
+- On test servers
+- In demo repos that the user clones locally
+
 For example, the [Play with Grafana Mimir](/tutorials/play-with-grafana-mimir/) tutorial provides a repo that users can clone in order to complete the tutorial. As a comparison, the Mimir [Storing exemplars in Grafana Mimir](/docs/mimir/latest/operators-guide/use-exemplars/storing-exemplars/) topic is a pure task that a user would follow to complete their work.
 
 If getting access to the tutorial data is complex, include the instructions in the steps of the tutorial. If getting access to the data is straightforward, include it in the "Before you begin" section.
 
 ## Publish your tutorial
 
-Your tutorial source is stored in your project repo in a `tutorials` folder and mounted to the tutorials repo so that it can be displayed on the [Tutorials](/tutorials) page. The source is stored in your project repo to make it easy for team members to review and edit the content. 
+Your tutorial source is stored in your project repo in a `tutorials` folder and mounted to the tutorials repo so that it can be displayed on the [Tutorials](/tutorials) page. The source is stored in your project repo to make it easy for team members to review and edit the content.
 
-The following sections describe how to hide the tutorial from your project's table of contents and to display it on the Tutorials page. 
+The following sections describe how to hide the tutorial from your project's table of contents and to display it on the Tutorials page.
 
 ### Hide your tutorial from your table of contents
 
@@ -114,20 +111,20 @@ To hide your tutorial from your documentation's table of contents:
 
 1. Open your project's `sources/_index.md` file.
 
-1. Add the following code to the `$.cascade` field in the YAML metadata. 
+1. Add the following code to the `$.cascade` field in the YAML metadata.
 
-    ```yaml
-    cascade:
-    - _target:
-        path: /docs/grafana-cloud/tutorials/**
-      _build:
-        list: false
-        render: false
-    - _target:
-        path: /docs/grafana-cloud/**
-    ```
+   ```yaml
+   cascade:
+     - _target:
+         path: /docs/grafana-cloud/tutorials/**
+       _build:
+         list: false
+         render: false
+     - _target:
+         path: /docs/grafana-cloud/**
+   ```
 
-    > **Note**: Create the `cascade` field if it does not exist. Substitute your repo for `grafana-cloud` in this example.
+   > **Note**: Create the `cascade` field if it does not exist. Substitute your repo for `grafana-cloud` in this example.
 
 ### Add your tutorial to the Tutorials page
 
@@ -137,13 +134,13 @@ To add your tutorial to the Tutorials page:
 
 1. Add the following code to the `$.manual_mounts` field in the `config/_default/config.yaml` file in the website repo:
 
-    ```yaml
-    manual_mounts:
-      - source: content/docs/grafana-cloud/tutorials/k8s-monitoring-app
-        target: content/tutorials/k8s-monitoring-app
-    ```
+   ```yaml
+   manual_mounts:
+     - source: content/docs/grafana-cloud/tutorials/k8s-monitoring-app
+       target: content/tutorials/k8s-monitoring-app
+   ```
 
-    > **Note**: Create the `manual_mounts` field if it does not exist. Substitute the source and target with your tutorial's path and name.
+   > **Note**: Create the `manual_mounts` field if it does not exist. Substitute the source and target with your tutorial's path and name.
 
 1. Add the following code to the `list` field in the `data/tutorials.yaml` file in the website repo:
 
@@ -153,10 +150,11 @@ To add your tutorial to the Tutorials page:
        level: beginner
        type: tutorial
    ```
-    > **Note**: Create the `list` field if it does not exist. Substitute the path to your tutorial for `page` and specify the `level` for your tutorial. The `level` and `type` fields are used to filter the Tutorials page.
+
+   > **Note**: Create the `list` field if it does not exist. Substitute the path to your tutorial for `page` and specify the `level` for your tutorial. The `level` and `type` fields are used to filter the Tutorials page.
 
 1. After peer reviews, merge your PR and test that your tutorial displays correctly on the Tutorials page.
-    
+
 ## Tutorial topic example
 
 Refer to the following for tutorial examples:

--- a/docs/sources/writing-guide/useful-link-text/index.md
+++ b/docs/sources/writing-guide/useful-link-text/index.md
@@ -2,8 +2,6 @@
 title: Write useful link text
 menuTitle: Write useful link text
 description: Learn how to write useful link text well.
-aliases:
-  - /docs/writers-toolkit/latest/writing-guide/useful-link-text/
 weight: 100
 keywords:
 ---
@@ -19,26 +17,26 @@ The primary purpose of link text is to give users a short summary of the link de
 When writing link text, pay attention to words, quantity of links, and the length of link text.
 
 ### Words
- 
-* Make link text abundantly obvious as to what the next page is about.
-* Use or do not use words such as *Click here*, *More*, and *Read more*:
-  
-  * Use them if they are on a website card.
 
-  * Do not use them as standalone link text, because they can be confusing when a screen reader reads them out of context.
-  
-* When linking to GitHub, include `GitHub repository` in the sentence text or link text.
+- Make link text abundantly obvious as to what the next page is about.
+- Use or do not use words such as _Click here_, _More_, and _Read more_:
 
-  For example: 
+  - Use them if they are on a website card.
 
-  * “To learn more, go to the `[faro-web-sdk]()` repository.”
-  * ”To learn more about Grafana Faro, go to its `[repository]()`.”
+  - Do not use them as standalone link text, because they can be confusing when a screen reader reads them out of context.
 
-* When linking from outside of a documentation page, include `documentation` in the text.
+- When linking to GitHub, include `GitHub repository` in the sentence text or link text.
+
+  For example:
+
+  - “To learn more, go to the `[faro-web-sdk]()` repository.”
+  - ”To learn more about Grafana Faro, go to its `[repository]()`.”
+
+- When linking from outside of a documentation page, include `documentation` in the text.
 
 ### Quantity
 
-* Aim for no more than two links per paragraph.
+- Aim for no more than two links per paragraph.
 
   Some links are essential for additional context, and others are nice to have but not necessary.
 
@@ -46,20 +44,20 @@ When writing link text, pay attention to words, quantity of links, and the lengt
 
 ### Length
 
-* Keep link text short and concise.
-* Never start with articles: *a*, *an*, or *the*.
-* Do not link whole sentences; aim for a maximum of four to five words.
+- Keep link text short and concise.
+- Never start with articles: _a_, _an_, or _the_.
+- Do not link whole sentences; aim for a maximum of four to five words.
 
 ## Examples
 
-| Use | Do not use |
-|-|-|
-| `[Learn more about cluster navigation]()` or learn more about `[cluster navigation]()` | `[Learn more]()` |
-| To learn more read our `[Grafana Phlare blog post]()` | To learn more about Phlare read our `[blog post]()` |
-| read more about specific `[metrics and alerting rules]()` | `[read more]()` |
-| `[our <company name> products]()` or `[<company name> products]()` | `[our products]()` |
-| visit the `[<company name> website]()` or visit` [<company name>.com`]() | `[visit our website]()` |
-| `[SNMP exporter]()` | `[exporter]()` |
-| `[KubeCon + CloudNativeCon North America 2022]()` | `[KubeCon event]()` |
-| The basic `[definition of cardinality]()` | The `[basic definition]()` of cardinality |
-| see `[configuring Kubernetes monitoring]()` | `[see configuring Kubernetes monitoring]()` |
+| Use                                                                                    | Do not use                                          |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `[Learn more about cluster navigation]()` or learn more about `[cluster navigation]()` | `[Learn more]()`                                    |
+| To learn more read our `[Grafana Phlare blog post]()`                                  | To learn more about Phlare read our `[blog post]()` |
+| read more about specific `[metrics and alerting rules]()`                              | `[read more]()`                                     |
+| `[our <company name> products]()` or `[<company name> products]()`                     | `[our products]()`                                  |
+| visit the `[<company name> website]()` or visit` [<company name>.com`]()               | `[visit our website]()`                             |
+| `[SNMP exporter]()`                                                                    | `[exporter]()`                                      |
+| `[KubeCon + CloudNativeCon North America 2022]()`                                      | `[KubeCon event]()`                                 |
+| The basic `[definition of cardinality]()`                                              | The `[basic definition]()` of cardinality           |
+| see `[configuring Kubernetes monitoring]()`                                            | `[see configuring Kubernetes monitoring]()`         |


### PR DESCRIPTION
See individual commits. 

Updated documentation is in [4eaf204](https://github.com/grafana/writers-toolkit/pull/226/commits/4eaf204ac203aa2fcf2fd06013b2b01f3c07e9e5).

Closes [4eaf204](https://github.com/grafana/writers-toolkit/pull/226/commits/4eaf204ac203aa2fcf2fd06013b2b01f3c07e9e5).