### PR TITLE
Pin docs.mk to a specific sha to prevent diffs

### DIFF
--- a/docs/docs.mk
+++ b/docs/docs.mk
@@ -96,4 +96,4 @@ doc-validator/%:
 	DOCS_IMAGE=$(DOC_VALIDATOR_IMAGE) DOC_VALIDATOR_INCLUDE=$(subst doc-validator/,,$@) $(PWD)/make-docs $(PROJECTS)
 
 docs.mk: ## Fetch the latest version of this Makefile from Writers' Toolkit.
-	curl -s -LO https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
+	curl -s -LO https://raw.githubusercontent.com/grafana/writers-toolkit/fd179ba615cbaf8cf738e12fe34a951b505ce5a1/docs/docs.mk


### PR DESCRIPTION
We saw a [build failure](https://drone.grafana.net/grafana/loki/22538/5/2) after this common Makefile was included in the Loki repo.

My theory here is that since `docs.mk` is pulling the latest from `main`, it can be out of sync with what's checked in to the Loki repo. As a result, after we generate our helm reference doc and run a `git diff`, it picks up the diff between the version we have checked in and the latest in `main`. As long as we pin this to a specific sha, we should avoid that problem in the future.

We had to temporarily [revert](https://github.com/grafana/loki/pull/9146) the addition of the common Makefile as it started failing CI once there was drift between the version we had checked in and `main` in this repo.