### PR TITLE
Document date parameter

### DIFF
--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -47,6 +47,16 @@ The following headings describe what each element does and provides guidelines f
 Provides an HTML redirect from the pages in the list to the current page.
 For more information, refer to [Hugo aliases](#hugo-aliases).
 
+### date
+
+Describes the publish date of the page.
+Hugo produces XML page outputs for use by RSS feeds where users can be notified of updates.
+Customers use RSS feeds of our release notes pages to be notified of new releases.
+Therefore, the `date` front matter is recommended for release note pages.
+
+The value to the `date` field should be a full ISO 8601 timestamp.
+For example, `date: "2023-04-24T00:00:00Z"` is 12:00 AM, Apr 24 Coordinated Universal Time (UTC).
+
 ### description
 
 **Required.**

--- a/docs/sources/writing-guide/front-matter/index.md
+++ b/docs/sources/writing-guide/front-matter/index.md
@@ -49,7 +49,7 @@ For more information, refer to [Hugo aliases](#hugo-aliases).
 
 ### date
 
-Describes the publish date of the page.
+Describes the initial publish date of the page.
 Hugo produces XML page outputs for use by RSS feeds where users can be notified of updates.
 Customers use RSS feeds of our release notes pages to be notified of new releases.
 Therefore, the `date` front matter is recommended for release note pages.


### PR DESCRIPTION
- Update cascading front matter documentation to explain the two forms
- Fix heading hierarchy and emphasize advice with note admonition
- Document date front matter parameter
