### PR TITLE
Feat: document shortcode for admonitions

### DIFF
--- a/docs/sources/style-guide/style-conventions/index.md
+++ b/docs/sources/style-guide/style-conventions/index.md
@@ -117,11 +117,21 @@ To focus a user's attention, Grafana Labs documentation includes notes, tips, ca
 
 The most common admonition is a note. A note provides additional information that the user should be aware of.
 
-The Markdown syntax for a note is `> **Note:**`. The note appears in the published output as follows:
+Notes have an admonition shortcode. The syntax is as follows:
 
-For example:
+```markdown
+{{%/* admonition type="note" */%}}
+This page describes a feature for Grafana 9.0 beta.
+{{%/* /admonition */%}}
+```
 
-> **Note:** This page describes a feature for Grafana 9.0 beta.
+
+This note appears in the published output as follows:
+
+{{% admonition type="note" %}}
+This page describes a feature for Grafana 9.0 beta.
+{{% /admonition %}}
+
 
 ### Tips
 
@@ -131,12 +141,39 @@ A tip describes a more efficient or alternate way of doing something. Tips are r
 
 A caution warns the user to proceed with caution. A caution emphasizes a course of action's potential downsides.
 
-> **Caution:** By disabling authentication requirements, anyone can access your Grafana instance. There is a considerable security risk associated with this.
+Cautions have an admonition shortcode. The syntax is as follows:
+
+```markdown
+{{%/* admonition type="caution" */%}}
+By disabling authentication requirements, anyone can access your Grafana instance.
+There is a considerable security risk associated with this.
+{{%/* /admonition */%}}
+```
+
+This caution appears in the published output as follows:
+
+{{% admonition type="caution" %}}
+By disabling authentication requirements, anyone can access your Grafana instance. There is a considerable security risk associated with this.
+{{% /admonition %}}
+
 
 ### Warnings
 
 A warning informs the user not to do something. Warnings are usually reserved for actions that, if performed, could cause harm to hardware, software, or data.
 
-For example:
+Warnings have an admonition shortcode. The syntax is as follows:
 
-> **Warning:** Do not back up your dashboards in Grafana. You might not be able to recover a dashboard if it is deleted.
+```markdown
+{{%/* admonition type="warning" */%}}
+Do not back up your dashboards in Grafana.
+You might not be able to recover a dashboard if it is deleted.
+{{%/* /admonition */%}}
+```
+
+This warning appears in the published output as follows:
+
+{{% admonition type="warning" %}}
+By disabling authentication requirements, anyone can access your Grafana instance.
+There is a considerable security risk associated with this.
+{{% /admonition %}}
+

--- a/docs/sources/style-guide/style-conventions/index.md
+++ b/docs/sources/style-guide/style-conventions/index.md
@@ -115,7 +115,7 @@ To focus a user's attention, Grafana Labs documentation includes notes, cautions
 
 To standardize styling, each admonition has a special shortcode declaration.
 The following sections provide examples how to write each type.
-For the complete syntax reference, refer to [Shortcodes]({{% relref "../../writing-guide/shortcodes" %}}).
+For the complete syntax reference, refer to [Shortcodes]({{< relref "../../writing-guide/shortcodes" >}}).
 
 ### Notes
 

--- a/docs/sources/style-guide/style-conventions/index.md
+++ b/docs/sources/style-guide/style-conventions/index.md
@@ -111,13 +111,18 @@ As much as possible, use the exact title of the page or section you are linking 
 
 ## Admonitions
 
-To focus a user's attention, Grafana Labs documentation includes notes, tips, cautions, and warnings.
+To focus a user's attention, Grafana Labs documentation includes notes, cautions, and warnings.
+
+To standardize styling, each admonition has a special shortcode declaration.
+The following sections provide examples how to write each type.
+For the complete syntax reference, refer to [Shortcodes]({{% relref "../../writing-guide/shortcodes" %}}).
 
 ### Notes
 
-The most common admonition is a note. A note provides additional information that the user should be aware of.
+A note provides additional information that the user should be aware of.
+Notes are the most common admonition.
 
-Notes have an admonition shortcode. The syntax is as follows:
+The syntax for a note admonition is as follows:
 
 ```markdown
 {{%/* admonition type="note" */%}}
@@ -125,23 +130,18 @@ This page describes a feature for Grafana 9.0 beta.
 {{%/* /admonition */%}}
 ```
 
-
-This note appears in the published output as follows:
+On the published page, this note renders as follows:
 
 {{% admonition type="note" %}}
 This page describes a feature for Grafana 9.0 beta.
 {{% /admonition %}}
 
-
-### Tips
-
-A tip describes a more efficient or alternate way of doing something. Tips are rarely used.
-
 ### Cautions
 
-A caution warns the user to proceed with caution. A caution emphasizes a course of action's potential downsides.
+A caution warns the user to proceed with caution.
+A caution emphasizes a course of action's potential downsides.
 
-Cautions have an admonition shortcode. The syntax is as follows:
+The syntax for a caution admonition is as follows:
 
 ```markdown
 {{%/* admonition type="caution" */%}}
@@ -150,7 +150,7 @@ There is a considerable security risk associated with this.
 {{%/* /admonition */%}}
 ```
 
-This caution appears in the published output as follows:
+On the published page, this caution renders as follows:
 
 {{% admonition type="caution" %}}
 By disabling authentication requirements, anyone can access your Grafana instance. There is a considerable security risk associated with this.
@@ -159,9 +159,10 @@ By disabling authentication requirements, anyone can access your Grafana instanc
 
 ### Warnings
 
-A warning informs the user not to do something. Warnings are usually reserved for actions that, if performed, could cause harm to hardware, software, or data.
+A warning informs the user not to do something.
+Warnings are reserved for actions that could cause harm to hardware, software, or data.
 
-Warnings have an admonition shortcode. The syntax is as follows:
+The syntax for a warning admonition is as follows:
 
 ```markdown
 {{%/* admonition type="warning" */%}}
@@ -170,7 +171,7 @@ You might not be able to recover a dashboard if it is deleted.
 {{%/* /admonition */%}}
 ```
 
-This warning appears in the published output as follows:
+On the published page, this warning renders as follows:
 
 {{% admonition type="warning" %}}
 By disabling authentication requirements, anyone can access your Grafana instance.

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -29,7 +29,7 @@ The content of the admonition must be within opening and closing tags.
 
 | Parameter | Description                                                     | Required |
 |-----------|-----------------------------------------------------------------|----------|
-| `type`    | The type of admonition. One of `note`, `caution`, or `warning`. | yes |
+| `type`    | The type of admonition. One of `"note"`, `"caution"`, or `"warning"`. | yes |
 
 
 ### Example

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -23,7 +23,7 @@ The following sections describe shortcodes available for use in Grafana Markdown
 ## `admonition` shortcode
 
 The `admonition` shortcode renders its content in a blockquote or stylized banner.
-The style depends on the admonition type as defined in the Writers' Toolkit [Style conventions]({{% relref "../../style-guide/style-conventions" %}}).
+The style depends on the admonition type as defined in the Writers' Toolkit [Style conventions]({{< relref "../../style-guide/style-conventions" >}}).
 
 The content of the admonition must be within opening and closing tags.
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -20,7 +20,30 @@ The following sections describe shortcodes available for use in Grafana Markdown
 
 > **Note for internal Grafana Labs contributors**: The Grafana shortcode templates are defined in the `layouts/shortcodes` folder of the website repo. To request custom shortcodes, [create an issue](https://github.com/grafana/writers-toolkit/issues).
 
-## docs/shared shortcode
+## `admonition` shortcode
+
+The `admonition` shortcode renders its content in a blockquote or stylized banner.
+The style depends on the admonition type as defined in the Writers' Toolkit [Style conventions]({{% relref "../../style-guide/style-conventions" %}}).
+
+The content of the admonition must be within opening and closing tags.
+
+| Parameter | Description                                                     | Required |
+|-----------|-----------------------------------------------------------------|----------|
+| `type`    | The type of admonition. One of `note`, `caution`, or `warning`. | yes |
+
+
+### Example
+
+The following snippet renders an admonition of type `note` with a message `Kingston is the capital of Jamaica`.
+
+```html
+{{%/* admonition type="note" */%}}
+Kingston is the capital of Jamaica.
+{{%/* /admonition */%}}
+```
+
+
+## `docs/shared` shortcode
 
 The `docs/shared` shortcode lets you reuse content across the Grafana website by including shared pages from source content repositories. The source content repository must explicitly share the page by placing it into its `shared` directory.
 
@@ -54,7 +77,7 @@ The following shortcode inserts the latest version of `shared-page.md` from the 
 {{</* docs/shared lookup="shared-page.md" source="enterprise-metrics" version="latest" leveloffset="+1" */>}}
 ```
 
-## figure shortcode
+## `figure` shortcode
 
 The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. To add a figure, insert the `figure` shortcode with the following named parameters:
 
@@ -76,7 +99,7 @@ The `figure` shortcode renders an image with a caption using an HTML [`<figure>`
 {{</* figure class="float-right"  src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
 ```
 
-## section shortcode
+## `section` shortcode
 
 The `section` shortcode renders an unordered list of links to a page's child pages. To add a section, insert the `section` shortcode with the following optional parameters:
 


### PR DESCRIPTION
- Documents the `admonition` shortcode, fixes #231
- Removes the `tips` admonition, fixes #233 
- Standardizes shortcode document so shortcode names render in `code` element in headings  