### PR TITLE
docs: clarify markdown vs shortcode use cases for images

### DIFF
--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -171,7 +171,7 @@ Include images in a document using the following syntax:
 
 This follows the format `![alt text](URL)`.
 
-Alternatively, you can use the [figure shortcode]({{< relref "../shortcodes/#figure-shortcode" >}} if you need more image options, such as adding captions or controlling the image size.
+Alternatively, you can use the [figure shortcode]({{< relref "../shortcodes/#figure-shortcode" >}}) if you need more image options, such as adding captions or controlling the image size.
 
 Within Markdown, HTML is valid, but should be used sparingly:
 

--- a/docs/sources/writing-guide/markdown-guide/index.md
+++ b/docs/sources/writing-guide/markdown-guide/index.md
@@ -156,7 +156,7 @@ The preceding snippet displays as follows:
 
 ## Images
 
-_Do not_ use image shortcodes at this time. Instead, include images in a document using the following syntax:
+Include images in a document using the following syntax:
 
 ```markdown
 ![Alt text](link to image, starting with /static/img/docs/ if it is to an internal image "Title of image in sentence case")
@@ -171,7 +171,9 @@ _Do not_ use image shortcodes at this time. Instead, include images in a documen
 
 This follows the format `![alt text](URL)`.
 
-Within Markdown, HTML is valid and to be used sparingly:
+Alternatively, you can use the [figure shortcode]({{< relref "../shortcodes/#figure-shortcode" >}} if you need more image options, such as adding captions or controlling the image size.
+
+Within Markdown, HTML is valid, but should be used sparingly:
 
 ```html
 <img

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -79,7 +79,7 @@ The following shortcode inserts the latest version of `shared-page.md` from the 
 
 ## `figure` shortcode
 
-The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic markdown to add images]({{< reflref "../markdown-guide/#images" >}}). 
+The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic markdown to add images]({{< relref "../markdown-guide/#images" >}}). 
 
 To add a figure, insert the `figure` shortcode with the following named parameters:
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -81,7 +81,6 @@ The following shortcode inserts the latest version of `shared-page.md` from the 
 
 The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic markdown to add images]({{< reflref "../markdown-guide/#images" >}}). 
 
-
 To add a figure, insert the `figure` shortcode with the following named parameters:
 
 | Parameter        | Description                                                                                                                                                                                                                                                                | Required |

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -79,7 +79,10 @@ The following shortcode inserts the latest version of `shared-page.md` from the 
 
 ## `figure` shortcode
 
-The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. To add a figure, insert the `figure` shortcode with the following named parameters:
+The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic markdown to add images]({{< reflref "../markdown-guide/#images" >}}). 
+
+
+To add a figure, insert the `figure` shortcode with the following named parameters:
 
 | Parameter        | Description                                                                                                                                                                                                                                                                | Required |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -79,7 +79,7 @@ The following shortcode inserts the latest version of `shared-page.md` from the 
 
 ## `figure` shortcode
 
-The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic markdown to add images]({{< relref "../markdown-guide/#images" >}}). 
+The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic Markdown to add images]({{< relref "../markdown-guide/#images" >}}). 
 
 To add a figure, insert the `figure` shortcode with the following named parameters:
 


### PR DESCRIPTION
Add clarifying text for when to use markdown vs a shortcode for adding images in docs