### PR TITLE
Update CODEOWNERS to be North American support advocates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @GrafanaWriter @brendamuir @chri2547
+* @knylander-grafana @josmperez


### PR DESCRIPTION
@knylander-grafana and @josmperez have volunteered to be primary support for technical writers in the North American timezones and therefore I believe they should be the primary reviewers of any documentation.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
