### PR TITLE
jdb/2023 06 test doc validator reviewdog support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:latest"
+      image: "grafana/doc-validator:a5e1751-dirty"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
@@ -17,7 +17,7 @@ jobs:
           docs/sources
           /docs/writers-toolkit
           | reviewdog
-          '--efm=ERROR: %f:%l:%c %m'
+          -f=rdjsonl
           --fail-on-error
           --filter-mode=nofilter
           --name=doc-validator

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -23,7 +23,7 @@ The following sections describe shortcodes available for use in Grafana Markdown
 ## `admonition` shortcode
 
 The `admonition` shortcode renders its content in a blockquote or stylized banner.
-The style depends on the admonition type as defined in the Writers' Toolkit [Style conventions]({{< relref "../../style-guide/style-conventions" >}}).
+The style depends on the admonition type as defined in the Writers' Toolkit [Style conventions]({{< relref "../../style-guide/style-conventions/" >}}).
 
 The content of the admonition must be within opening and closing tags.
 


### PR DESCRIPTION
- Use RDJSONL format with structured doc-validator output
- Add a trailing slash to demonstrate suggestions
