### PR TITLE
Use doc-validator v3.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:latest"
+      image: "grafana/doc-validator:v3.0.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
@@ -17,7 +17,7 @@ jobs:
           docs/sources
           /docs/writers-toolkit
           | reviewdog
-          '--efm=ERROR: %f:%l:%c %m'
+          -f=rdjsonl
           --fail-on-error
           --filter-mode=nofilter
           --name=doc-validator


### PR DESCRIPTION
- Structured output for use with [`reviewdog`](https://github.com/reviewdog/reviewdog). You can achieve the original error output by piping the output to the following `jq` expression: `jq -r '"ERROR: \(.location.path):\(.location.range.start.line):\(.location.range.start.column): \(.message)"'`.
- Suggestions for simple link fixes. In GitHub, [`reviewdog`](https://github.com/reviewdog/reviewdog) comments these suggestions for convenient replacement.
- Support for anchors referring to repeated headings. In the case that a page has multiple headings that share the same text, the renderer appends a zero indexed, numbered suffix to the identifier. For example, when there are two headings that are both "Heading text", the first anchor identifier is `heading-text` and the second is `heading-text-1`.
- Error when running `doc-validator` on no files.