### PR TITLE
Updating the example link format from a bare link to a link with link text.

### DIFF
--- a/docs/sources/writing-guide/references/index.md
+++ b/docs/sources/writing-guide/references/index.md
@@ -33,7 +33,7 @@ All of the following destinations link https://grafana.com/docs/grafana/latest t
 To choose the correct link destination type, follow these steps:
 
 1. If the destination is external to the https://grafana.com website, use the fully specified HTTPS URL.
-   For example, https://github.com.
+   For example, `(GitHub)[https://github.com]`.
 1. If the source is reused as described in [Reuse directories of content with Hugo mounts]({{< relref "../reuse-directories" >}}):
 
    1. If the destination is also present in the destination mount, use a relative URL path.

--- a/docs/sources/writing-guide/references/index.md
+++ b/docs/sources/writing-guide/references/index.md
@@ -33,7 +33,7 @@ All of the following destinations link https://grafana.com/docs/grafana/latest t
 To choose the correct link destination type, follow these steps:
 
 1. If the destination is external to the https://grafana.com website, use the fully specified HTTPS URL.
-   For example, `(GitHub)[https://github.com]`.
+   For example, `[GitHub](https://github.com)`.
 1. If the source is reused as described in [Reuse directories of content with Hugo mounts]({{< relref "../reuse-directories" >}}):
 
    1. If the destination is also present in the destination mount, use a relative URL path.


### PR DESCRIPTION
The Writer's Toolkit page for [links and cross-references](https://grafana.com/docs/writers-toolkit/writing-guide/references/#understanding-hyperlinks) has a bare URL in the first example:
`For example, https://github.com.`

But all the rest of our link guidance suggests that we do not publish bare URLs, but provide link text.  The Style Guide [section on links](https://grafana.com/docs/writers-toolkit/style-guide/style-conventions/#links-and-references) implies that there should be link text.  As does the [Write useful link text ](https://grafana.com/docs/writers-toolkit/writing-guide/useful-link-text/)topic
`For example, [GitHub](https://github.com]`

