### PR TITLE
Document `docs/reference` shortcode

### DIFF
--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -176,7 +176,7 @@ The destination used in a rendered page derives from matching path prefixes:
 1. If the shortcode is rendered in a page that has the path prefix `/docs/grafana-cloud/`, the shortcode returns a relref to `/docs/grafana-cloud`.
 1. If the shortcode is rendered in a page that has the path prefix `/docs/mimir/`, the shortcode returns a relref to `/docs/grafana/<GRAFANA VERSION>`.
 
-In cases 1. and 3. the "version" variable `<GRAFANA VERSION>` is replaced with the value of the front matter `grafana_version` if present, or by the version inferred from the current page.
+In cases 1 and 3, the version variable `<GRAFANA VERSION>` is replaced with the value of the front matter `grafana_version` if present, or by the version inferred from the current page.
 For the page `/docs/grafana/latest/dashboards/`, the version is `latest`.
 For the page `/docs/mimir/next/dashboards/`, the version is `next`.
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -162,11 +162,14 @@ The destination used in a rendered page derives from matching path prefixes:
 {{%/* /docs/reference */%}}
 ```
 
-- _`LABEL`_ matches a link label used in a reference-style link (`[LINK TEXT][LABEL])`).
+- _`LABEL`_ matches the link label used in a reference-style link (`[LINK TEXT][LABEL])`).
   For more information about reference-style links, refer to [Daring Fireball: Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax#link).
 - _`PROJECT PATH PREFIX`_ is matched against the page’s URL path, where the first matching `PROJECT PATH PREFIX` is chosen.
+  The project of the destinations where you want _`REFERENCE`_ to be used.
+  For example, for Grafana, use `/docs/grafana/`, for Mimir, use `/docs/mimir/`.
 - _`REFERENCE`_ is the parameter that would typically be used in a `relref` shortcode.
   It can include the syntax `<SOMETHING VERSION>`, which is first looked up in the front matter before falling back to the version inferred from the page's version.
+  Any of the kinds of arguments documented in [Links and Cross References](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) can be used.
 
 ### Example
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -143,6 +143,43 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 {{</* section withDescriptions="true"*/>}}
 ```
 
+## `docs/reference` shortcode
+
+The `docs/reference` shortcode offers more flexible linking than the Hugo builtin `relref` shortcode.
+Reference links wrapped in the `docs/reference` shortcode can be defined with multiple destinations.
+The destination used in a the rendered page depends is chosen based upon matching path prefixes.
+
+```markdown
+{{%/* docs/reference */%}}
+[<LABEL>]: "<PATH PREFIX> -> <REFERENCE>"
+...
+{{%/* /docs/reference */%}}
+```
+
+- _`LABEL`_ matches a link label used in a reference-style link (`[LINK TEXT][LABEL])`).
+  For more information about reference-style links, refer to [Daring Fireball: Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax#link).
+- _`PROJECT PATH PREFIX`_ is matched against the page’s URL path.
+- _`REFERENCE`_ is the parameter that would typically be used in a `relref` shortcode.
+  It can include the special syntax `<SOMETHING VERSION>` which is first looked up in the front matter before falling back to the version inferred from the page's version.
+
+### Example
+
+```markdown
+{{%/* docs/reference */%}}
+[grafana]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>"
+[grafana]: "/docs/grafana-cloud/ -> /docs/grafana-cloud"
+[grafana]: "/docs/mimir/ -> /docs/grafana/<GRAFANA VERSION>"
+{{%/* /docs/reference */%}}
+```
+
+1. If the shortcode is rendered in a page that has the path prefix `/docs/grafana/`, the shortcode returns a relref to `/docs/grafana/<GRAFANA VERSION>`.
+1. If the shortcode is rendered in a page that has the path prefix `/docs/grafana-cloud/`, the shortcode returns a relref to `/docs/grafana-cloud`.
+1. If the shortcode is rendered in a page that has the path prefix `/docs/mimir/`, the shortcode returns a relref to `/docs/grafana/<GRAFANA VERSION>`.
+
+In cases 1. and 3. the "version" variable `<GRAFANA VERSION>` is replaced with the value of the front matter `grafana_version` if present, or by the version inferred from the current page.
+For the page `/docs/grafana/latest/dashboards/`, the version is `latest`.
+For the page `/docs/mimir/next/dashboards/`, the version is `next`.
+
 ## Escaping Hugo shortcodes
 
 If you need to display the syntax for a shortcode, you can escape it using this syntax:

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -151,7 +151,7 @@ The destination used in a rendered page derives from matching path prefixes:
 
 ```markdown
 {{%/* docs/reference */%}}
-[<LABEL>]: "<PATH PREFIX> -> <REFERENCE>"
+[<LABEL>]: "<PROJECT PATH PREFIX> -> <REFERENCE>"
 ...
 {{%/* /docs/reference */%}}
 ```

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -167,7 +167,7 @@ The destination used in a rendered page derives from matching path prefixes:
 - _`PROJECT PATH PREFIX`_ is matched against the page’s URL path, where the first matching `PROJECT PATH PREFIX` is chosen.
   The project of the destinations where you want _`REFERENCE`_ to be used.
   For example, for Grafana, use `/docs/grafana/`, for Mimir, use `/docs/mimir/`.
-- _`REFERENCE`_ is the parameter that would typically be used in a `relref` shortcode.
+- _`REFERENCE`_ is the same parameter used in a `relref` shortcode.
   It can include the syntax `<SOMETHING VERSION>`, which is first looked up in the front matter before falling back to the version inferred from the page's version.
   Any of the kinds of arguments documented in [Links and Cross References](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) can be used.
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -170,23 +170,49 @@ The destination used in a rendered page derives from matching path prefixes:
   It can include the syntax `<SOMETHING VERSION>`, which is first looked up in the front matter before falling back to the version inferred from the page's version.
   Any of the kinds of arguments documented in [Links and Cross References](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) can be used.
 
-### Example
+### Examples
+
+#### Version interpolation
+
+Given a page in versioned Grafana documentation containing the following the reference-style link:
+
+```markdown
+For more information about Grafana dashboards, refer to [Dashboards][dashboards].
+```
+
+Version interpolation of `/docs/reference` enables the use of absolute paths that resolve correctly, irrespective of version.
+In the following example, the `/docs/reference` shortcode replaces the variable `<GRAFANA VERSION>` with the version inferred from the current page.
+
+- If the page is `/docs/grafana/latest/alerting`, the inferred version is `latest`, and the returned reference is `/docs/grafana/latest/dashboards`.
+- If the page is `/docs/grafana/next/alerting`, the inferred version is `next`, and the returned reference is `/docs/grafana/next/dashboards`.
 
 ```markdown
 {{%/* docs/reference */%}}
-[grafana]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>"
-[grafana]: "/docs/grafana-cloud/ -> /docs/grafana-cloud"
-[grafana]: "/docs/mimir/ -> /docs/grafana/<GRAFANA VERSION>"
+[dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards"
 {{%/* /docs/reference */%}}
 ```
 
-1. If the shortcode is rendered in a page that has the path prefix `/docs/grafana/`, the shortcode returns a relref to `/docs/grafana/<GRAFANA VERSION>`.
-1. If the shortcode is rendered in a page that has the path prefix `/docs/grafana-cloud/`, the shortcode returns a relref to `/docs/grafana-cloud`.
-1. If the shortcode is rendered in a page that has the path prefix `/docs/mimir/`, the shortcode returns a relref to `/docs/grafana/<GRAFANA VERSION>`.
+You can override version inference using front matter.
+To override the value of `<GRAFANA VERSION>`, set the `grafana_version` parameter in the page's front matter.
+For example, with the front matter `grafana_version: next`, the shortcode replaces `<GRAFANA VERSION>` with `next`.
 
-In cases 1 and 3, the version variable `<GRAFANA VERSION>` is replaced with the value of the front matter `grafana_version` if present, or by the version inferred from the current page.
-For the page `/docs/grafana/latest/dashboards/`, the version is `latest`.
-For the page `/docs/mimir/next/dashboards/`, the version is `next`.
+#### Contextual destinations
+
+Given a page in versioned Grafana documentation containing the following the reference-style link:
+
+```markdown
+For more information about Grafana dashboards, refer to [Dashboards][dashboards].
+```
+
+The page is also mounted into Grafana Cloud documentation.
+The page in Grafana should link to the Grafana dashboards page and the page in Grafana Cloud should link to the Grafana Cloud dashboards page.
+
+```markdown
+{{%/* docs/reference */%}}
+[dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards"
+[dashboards]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/dashboards"
+{{%/* /docs/reference */%}}
+```
 
 ## Escaping Hugo shortcodes
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -158,7 +158,7 @@ The destination used in a rendered page derives from matching path prefixes:
 
 - _`LABEL`_ matches a link label used in a reference-style link (`[LINK TEXT][LABEL])`).
   For more information about reference-style links, refer to [Daring Fireball: Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax#link).
-- _`PROJECT PATH PREFIX`_ is matched against the page’s URL path.
+- _`PROJECT PATH PREFIX`_ is matched against the page’s URL path, where the first matching `PROJECT PATH PREFIX` is chosen.
 - _`REFERENCE`_ is the parameter that would typically be used in a `relref` shortcode.
   It can include the syntax `<SOMETHING VERSION>`, which is first looked up in the front matter before falling back to the version inferred from the page's version.
 

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -147,7 +147,7 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo builtin `relref` shortcode.
 Reference links wrapped in the `docs/reference` shortcode can be defined with multiple destinations.
-The destination used in a the rendered page depends is chosen based upon matching path prefixes.
+The destination used in a rendered page derives from matching path prefixes:
 
 ```markdown
 {{%/* docs/reference */%}}

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -146,11 +146,10 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 ## `docs/reference` shortcode
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo builtin `relref` shortcode.
-If content is sourced from one location, and published in multiple locations, the `docs/reference` shortcode helps you control the appropriate link location.
+When content from one repository is published to more than one documentation set, the `docs/reference` shortcode lets you specify appropriate links for each doc set.
 
 For example, alerting documentation is sourced from the Grafana repository and published to both Grafana documentation and Grafana Cloud documentation.
-Any link from alerting documentation to dashboard documentation, which is also published to both Grafana and Grafana Cloud, needs to be specific as to which destination is appropriate for the audience.
-
+Any link from alerting documentation to dashboard documentation, which is also published to both Grafana and Grafana Cloud, needs to be specific as to which destination is appropriate for the product documentation.
 Grafana Cloud alerting documentation should link to Grafana Cloud dashboard documentation, and Grafana alerting documentation should link to Grafana dashboard documentation.
 
 The destination used in a rendered page derives from matching path prefixes:

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -146,7 +146,13 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 ## `docs/reference` shortcode
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo builtin `relref` shortcode.
-Reference links wrapped in the `docs/reference` shortcode can be defined with multiple destinations.
+If content is sourced from one location, and published in multiple locations, the `docs/reference` shortcode helps you control the appropriate link location.
+
+For example, alerting documentation is sourced from the Grafana repository and published to both Grafana documentation and Grafana Cloud documentation.
+Any link from alerting documentation to dashboard documentation, which is also published to both Grafana and Grafana Cloud, needs to be specific as to which destination is appropriate for the audience.
+
+Grafana Cloud alerting documentation should link to Grafana Cloud dashboard documentation, and Grafana alerting documentation should link to Grafana dashboard documentation.
+
 The destination used in a rendered page derives from matching path prefixes:
 
 ```markdown

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -160,7 +160,7 @@ The destination used in a rendered page derives from matching path prefixes:
   For more information about reference-style links, refer to [Daring Fireball: Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax#link).
 - _`PROJECT PATH PREFIX`_ is matched against the page’s URL path.
 - _`REFERENCE`_ is the parameter that would typically be used in a `relref` shortcode.
-  It can include the special syntax `<SOMETHING VERSION>` which is first looked up in the front matter before falling back to the version inferred from the page's version.
+  It can include the syntax `<SOMETHING VERSION>`, which is first looked up in the front matter before falling back to the version inferred from the page's version.
 
 ### Example
 


### PR DESCRIPTION
For context on the need, refer to [2023-04 Flexible linking -- Problem](https://docs.google.com/document/d/1F9aiHhyruW0d_zMoL5yjG37Qo-OZ--x4Ivx2Hdu1cYs/edit#heading=h.xxn36c2bhtyg) and [2023-04 Flexible linking -- Consensus](https://docs.google.com/document/d/1F9aiHhyruW0d_zMoL5yjG37Qo-OZ--x4Ivx2Hdu1cYs/edit#heading=h.ve4du26wqsib).

I'd like to use this documentation to drive the implementation.
The documentation should help a user use this shortcode with confidence, if anything is unclear or you believe it is overly complicated, please add comments to this PR and I will incorporate the feedback in both the documentation and the implementation.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

Supersedes #262