### PR TITLE
Add make doc example

### DIFF
--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -104,7 +104,7 @@ In this example, the image has a CSS class that makes the image display floated 
 {{</* figure class="float-right"  src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
 ```
 
-In this example, the image's display size is change to have a maximum width of 50%. The `max-width` value must have a unit of measurement, such as pixels or percentages.
+In this example, the image's display size is changed to have a maximum width of 50%. The `max-width` value must have a unit of measurement, such as pixels or percentages.
 
 ```markdown
 {{</* figure max-width="50%" src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}

--- a/docs/sources/writing-guide/shortcodes/index.md
+++ b/docs/sources/writing-guide/shortcodes/index.md
@@ -98,8 +98,16 @@ To add a figure, insert the `figure` shortcode with the following named paramete
 
 ### Example
 
+In this example, the image has a CSS class that makes the image display floated to the right.
+
 ```markdown
 {{</* figure class="float-right"  src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
+```
+
+In this example, the image's display size is change to have a maximum width of 50%. The `max-width` value must have a unit of measurement, such as pixels or percentages.
+
+```markdown
+{{</* figure max-width="50%" src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
 ```
 
 ## `responsive-table` shortcode

--- a/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
@@ -66,7 +66,7 @@ make docs PROJECTS="tempo::tempo-doc-work"
 
 The format is `<PROJECT>[:VERSION[:REPOSITORY[:DIR]]].`
 The example mounts the `PROJECT` tempo, at the default `VERSION` latest, using the `REPOSITORY` `tempo-doc-work`, and the default `DIR` `docs/sources`.
-This example builds the Tempo documentation from the local working directory, `tempo-doc-work` instead of the standard `tempo` directory.
+This example builds the Tempo documentation from the local working directory, `tempo-doc-work`, instead of the standard `tempo` directory.
 
 ## Reference
 
@@ -147,7 +147,7 @@ Each argument has four fields separated by colons (`:`) and optional fields can 
   The `DIR` field is optional and defaults to the scripts internal mapping of project names to documentation source directories.
   For most projects, this is the `docs/sources` directory.
 
-This example builds the Grafana documentation and the Tempo documentation from the local repository, tempo-doc-work.
+This example builds the Grafana documentation and the Tempo documentation from the local repository, `tempo-doc-work`.
 
 ```bash
 make docs PROJECTS="grafana tempo::tempo-doc-work"
@@ -155,7 +155,7 @@ make docs PROJECTS="grafana tempo::tempo-doc-work"
 
 #### REPOS_PATH
 
-The `REPOS_PATH` environment variable is a colon (`:`) separated list of paths in which to look for project repositories.
+The `REPOS_PATH` environment variable is a colon-separated list of paths in which to look for project repositories.
 Only directories within the paths specified in `REPOS_PATH` are checked for projects.
 
 By default, the script determines the `REPOS_PATH` to be the parent directory of the `grafana/technical-documentation` repository.

--- a/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
@@ -59,11 +59,14 @@ make docs PROJECTS='grafana grafana-cloud'
 
 Let's say that you have forked the main project repository, so your local working directory name doesn't match the project name.
 You can use the `PROJECTS` option to define the local cloned repository (see the Arguments section below).
-This example builds the Tempo documentation from the local working directory, `tempo-doc-work` instead of the standard `tempo` directory.
 
 ```bash
 make docs PROJECTS="tempo::tempo-doc-work"
 ```
+
+The format is `<PROJECT>[:VERSION[:REPOSITORY[:DIR]]].`
+The example mounts the `PROJECT` tempo, at the default `VERSION` latest, using the `REPOSITORY` `tempo-doc-work`, and the default `DIR` `docs/sources`.
+This example builds the Tempo documentation from the local working directory, `tempo-doc-work` instead of the standard `tempo` directory.
 
 ## Reference
 

--- a/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
+++ b/docs/sources/writing-guide/tooling-and-workflows/run-a-local-webserver/index.md
@@ -57,6 +57,14 @@ To specifically build Grafana and Grafana Cloud documentation:
 make docs PROJECTS='grafana grafana-cloud'
 ```
 
+Let's say that you have forked the main project repository, so your local working directory name doesn't match the project name.
+You can use the `PROJECTS` option to define the local cloned repository (see the Arguments section below).
+This example builds the Tempo documentation from the local working directory, `tempo-doc-work` instead of the standard `tempo` directory.
+
+```bash
+make docs PROJECTS="tempo::tempo-doc-work"
+```
+
 ## Reference
 
 The `make docs` target uses the [`make-docs`](https://github.com/grafana/writers-toolkit/blob/main/scripts/make-docs) script to mount local documentation into the Hugo build.
@@ -135,6 +143,12 @@ Each argument has four fields separated by colons (`:`) and optional fields can 
 
   The `DIR` field is optional and defaults to the scripts internal mapping of project names to documentation source directories.
   For most projects, this is the `docs/sources` directory.
+
+This example builds the Grafana documentation and the Tempo documentation from the local repository, tempo-doc-work.
+
+```bash
+make docs PROJECTS="grafana tempo::tempo-doc-work"
+```
 
 #### REPOS_PATH
 


### PR DESCRIPTION
Adds a make doc example covering when the project directory doesn't match the standard project. 