### PR TITLE
Add note to modals.

### DIFF
--- a/docs/sources/style-guide/ux-writing/index.md
+++ b/docs/sources/style-guide/ux-writing/index.md
@@ -259,7 +259,7 @@ An alert modal displays an important message in a way that attracts the user's a
 Assume that some of your users might not understand technical terms and need simple, clear alert messages. Like other UI elements, use sentence case, plain language, and active voice in alerts.
 
 {{% admonition type="note" %}}
-The word "modal" is considered jargon and should not be used when writing user documenation. Use "dialog box" instead.
+The word "modal" is considered jargon and should not be used when writing documenation, except for developer documentation of code referencing a `modal`. Use "dialog box" instead.
 {{% /admonition %}}
 
 ### Severity levels

--- a/docs/sources/style-guide/ux-writing/index.md
+++ b/docs/sources/style-guide/ux-writing/index.md
@@ -258,6 +258,10 @@ An alert modal displays an important message in a way that attracts the user's a
 
 Assume that some of your users might not understand technical terms and need simple, clear alert messages. Like other UI elements, use sentence case, plain language, and active voice in alerts.
 
+{{% admonition type="note" %}}
+The word "modal" is considered jargon and should not be used when writing user documenation.  Use "dialog box" instead.
+{{% /admonition %}}
+
 ### Severity levels
 
 Alert modals have severity levels (error, warning, info, and success) with different colors used for each level:

--- a/docs/sources/style-guide/ux-writing/index.md
+++ b/docs/sources/style-guide/ux-writing/index.md
@@ -259,7 +259,7 @@ An alert modal displays an important message in a way that attracts the user's a
 Assume that some of your users might not understand technical terms and need simple, clear alert messages. Like other UI elements, use sentence case, plain language, and active voice in alerts.
 
 {{% admonition type="note" %}}
-The word "modal" is considered jargon and should not be used when writing user documenation.  Use "dialog box" instead.
+The word "modal" is considered jargon and should not be used when writing user documenation. Use "dialog box" instead.
 {{% /admonition %}}
 
 ### Severity levels


### PR DESCRIPTION
We discussed "modals" in the Style Council meeting this week.
Adding a note to the style guide to clarify not to use the term in documentation.