### PR TITLE
docs: add `docs/reference` shortcode guidance

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -175,7 +175,7 @@ Set the reference at the end of the page as follows:
 The content within the shortcode tags is as follows:
 
 - `label` - The label for the shortcode. This is the text that you'll use in the body text. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
-- `project path prefix` - Designates the destination project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.
+- `project path prefix` - Designates the target project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.
 - `reference` - The path to the destination file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
 
 Then add the link in the body of the file in the following format:

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -175,7 +175,7 @@ Set the reference at the end of the document as follows:
 The content within the shortcode tags is as follows:
 
 - `label` - The label for the shortcode. This is the text that you'll use in the body text. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
-- `project path prefix` - Designates the destination project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.  
+- `project path prefix` - Designates the destination project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.
 - `reference` - The path to the file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
 
 Then add the link in the body of the file in the following format:
@@ -193,7 +193,7 @@ For example, with the front matter `grafana_version: next`, the shortcode replac
 
 ### Other use cases
 
-The `docs/reference` shortcode is also useful when you want to link to the same destination multiple times in one file. 
+The `docs/reference` shortcode is also useful when you want to link to the same destination multiple times in one file.
 It allows you to specify the link destination once while you use the label multiple times. For example:
 
 **Reference:**

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -158,12 +158,12 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo built-in `relref` shortcode.
 
-Use this code when content from one repository is published to more than one documentation set, because it lets you specify appropriate links for each doc set in one part of the file (usually at end of the file, like a footer) while using the link label in the body text.
+Use this shortcode when content from one repository is published to more than one documentation set, because it lets you specify appropriate links for each doc set in one part of the file (usually at end of the file, like a footer) while using the link label in the body text.
 
 For example, a page in versioned Grafana documentation is also mounted in the Grafana Cloud documentation.
 The page in Grafana should link to the Grafana dashboards page but the page in Grafana Cloud should link to the Grafana Cloud dashboards page.
 
-Set the reference at the end of the document as follows:
+Set the reference at the end of the page as follows:
 
 ```markdown
 {{%/* docs/reference */%}}
@@ -176,7 +176,7 @@ The content within the shortcode tags is as follows:
 
 - `label` - The label for the shortcode. This is the text that you'll use in the body text. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
 - `project path prefix` - Designates the destination project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.
-- `reference` - The path to the file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
+- `reference` - The path to the destination file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
 
 Then add the link in the body of the file in the following format:
 
@@ -187,7 +187,7 @@ For more information about Grafana dashboards, refer to the [Dashboards document
 - If the page you're on is `/docs/grafana/latest/alerting/`, the inferred version is `latest`, and the returned reference is `/docs/grafana/latest/dashboards`.
 - If the page you're on is `/docs/grafana/next/alerting/`, the inferred version is `next`, and the returned reference is `/docs/grafana/next/dashboards`.
 
-You can override version inference using front matter.
+You can override version inference by including additional metadata in the front matter of the file.
 To override the value of `<GRAFANA VERSION>`, set the `grafana_version` parameter in the page's front matter.
 For example, with the front matter `grafana_version: next`, the shortcode replaces `<GRAFANA VERSION>` with `next`.
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -154,6 +154,62 @@ This shortcode inserts a lists of links to the page's subpages and includes the 
 {{</* section withDescriptions="true"*/>}}
 ```
 
+## `docs/reference` shortcode
+
+The `docs/reference` shortcode offers more flexible linking than the Hugo built-in `relref` shortcode.
+
+Use this code when content from one repository is published to more than one documentation set, because it lets you specify appropriate links for each doc set in one part of the file (usually at end of the file, like a footer) while using the link label in the body text.
+
+For example, a page in versioned Grafana documentation is also mounted in the Grafana Cloud documentation.
+The page in Grafana should link to the Grafana dashboards page but the page in Grafana Cloud should link to the Grafana Cloud dashboards page.
+
+Set the reference at the end of the document as follows:
+
+```markdown
+{{%/* docs/reference */%}}
+[dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards"
+[dashboards]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/dashboards"
+{{%/* /docs/reference */%}}
+```
+
+The content within the shortcode tags is as follows:
+
+- `label` - The label for the shortcode. This is the text that you'll use in the body text. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
+- `project path prefix` - Designates the destination project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.  
+- `reference` - The path to the file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
+
+Then add the link in the body of the file in the following format:
+
+```markdown
+For more information about Grafana dashboards, refer to the [Dashboards documentation][dashboards].
+```
+
+- If the page you're on is `/docs/grafana/latest/alerting/`, the inferred version is `latest`, and the returned reference is `/docs/grafana/latest/dashboards`.
+- If the page you're on is `/docs/grafana/next/alerting/`, the inferred version is `next`, and the returned reference is `/docs/grafana/next/dashboards`.
+
+You can override version inference using front matter.
+To override the value of `<GRAFANA VERSION>`, set the `grafana_version` parameter in the page's front matter.
+For example, with the front matter `grafana_version: next`, the shortcode replaces `<GRAFANA VERSION>` with `next`.
+
+### Other use cases
+
+The `docs/reference` shortcode is also useful when you want to link to the same destination multiple times in one file. 
+It allows you to specify the link destination once while you use the label multiple times. For example:
+
+**Reference:**
+
+```markdown
+{{%/* docs/reference */%}}
+[Grafana website]: "/ -> www.grafana.com"
+{{%/* /docs/reference */%}}
+```
+
+**Body text:**
+
+```markdown
+Find more information on [Grafana][Grafana website].
+```
+
 ## Escaping Hugo shortcodes
 
 If you need to display the syntax for a shortcode, you can escape it using this syntax:

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -174,7 +174,7 @@ Set the reference at the end of the page as follows:
 
 The content within the shortcode tags is as follows:
 
-- `label` - The label for the shortcode. This is the text that you'll use in the body text. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
+- `label` - The label you'll use in the reference-style links in the file. In the example above, the label is `dashboards`. The label can be multiple words (for example, [dashboard docs]) and can include spaces.
 - `project path prefix` - Designates the target project. In the example above, the path prefixes are `/docs/grafana/` for Grafana and `/docs/grafana-cloud/` for Cloud.
 - `reference` - The path to the destination file. It can include `<SOMETHING VERSION>`, which is either taken from front matter of (which file) or falls back to being inferred from the version of the page. This enables the use of absolute paths that resolve correctly, irrespective of version. When including a version, for the target project, use the name of the project, with spaces but no hyphens or underscores, all upper-cased (for example, grafana = GRAFANA, grafana-cloud = GRAFANA CLOUD).
 


### PR DESCRIPTION
This PR replaces PRs #264 and #271. Starting a new PR because of major structural changes to the Writer's Toolkit since the branches for those original PRs were cut.

***

For context on the need, refer to [2023-04 Flexible linking -- Problem](https://docs.google.com/document/d/1F9aiHhyruW0d_zMoL5yjG37Qo-OZ--x4Ivx2Hdu1cYs/edit#heading=h.xxn36c2bhtyg) and [2023-04 Flexible linking -- Consensus](https://docs.google.com/document/d/1F9aiHhyruW0d_zMoL5yjG37Qo-OZ--x4Ivx2Hdu1cYs/edit#heading=h.ve4du26wqsib).

I'd like to use this documentation to drive the implementation.
The documentation should help a user use this shortcode with confidence, if anything is unclear or you believe it is overly complicated, please add comments to this PR and I will incorporate the feedback in both the documentation and the implementation.

Signed-off-by: Jack Baldry [jack.baldry@grafana.com](mailto:jack.baldry@grafana.com)

Supersedes https://github.com/grafana/writers-toolkit/pull/262, #264, and #271  