### PR TITLE
Update beyla source to reflect the new repository name

### DIFF
--- a/docs/make-docs
+++ b/docs/make-docs
@@ -189,7 +189,6 @@ EOF
 fi
 
 SOURCES_as_code='as-code-docs'
-SOURCES_beyla='ebpf-autoinstrument'
 SOURCES_enterprise_metrics='backend-enterprise'
 SOURCES_enterprise_metrics_='backend-enterprise'
 SOURCES_grafana_cloud='website'


### PR DESCRIPTION
Now the repository is called `beyla` which matches the project name. Previously it was `ebpf-autoinstrument`.