### PR TITLE
Generate Vale configuration from common source and disable GoogleUnits rule

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,13 +1,9 @@
-StylesPath = vale
 MinAlertLevel = suggestion
-
 Packages = Google, https://github.com/jdbaldry/Hugo/releases/download/v0.2.0-rc.1/Hugo.zip
-
+StylesPath = vale
 [*.md]
 BasedOnStyles = Google, Grafana
-
 Google.Quotes = NO
+Google.Units = NO
 Google.WordList = NO
-
-# https://github.com/errata-ai/vale/issues/288
 TokenIgnores = (<http[^\n]+>+?)

--- a/vale/.vale.ini
+++ b/vale/.vale.ini
@@ -1,13 +1,9 @@
-StylesPath = /etc/vale/styles
 MinAlertLevel = suggestion
-
 Packages = https://github.com/jdbaldry/Hugo/releases/download/v0.2.0-rc.1/Hugo.zip
-
+StylesPath = /etc/vale/styles
 [*.md]
 BasedOnStyles = Google, Grafana
-
 Google.Quotes = NO
+Google.Units = NO
 Google.WordList = NO
-
-# https://github.com/errata-ai/vale/issues/288
 TokenIgnores = (<http[^\n]+>+?)

--- a/vale/.vale.jsonnet
+++ b/vale/.vale.jsonnet
@@ -1,0 +1,32 @@
+{
+  configuration: {
+    main: {
+      StylesPath: '/etc/vale/styles',
+      MinAlertLevel: 'suggestion',
+
+      Packages: 'https://github.com/jdbaldry/Hugo/releases/download/v0.2.0-rc.1/Hugo.zip',
+    },
+    sections: {
+      '*.md': {
+        BasedOnStyles: 'Google, Grafana',
+
+        // More often than not, we need to be consistent with Prometheus units or units used Grafana UI which are not represented in the form encouraged by SI.
+        'Google.Quotes': 'NO',
+        'Google.Units': 'NO',
+        'Google.WordList': 'NO',
+
+        // https://github.com/errata-ai/vale/issues/288
+        TokenIgnores: @'(<http[^\n]+>+?)',
+      },
+    },
+  },
+
+  container: std.manifestIni(self.configuration),
+
+  repository: std.manifestIni(self.configuration {
+    main+: {
+      StylesPath: 'vale',
+      Packages: 'Google, ' + super.Packages,
+    },
+  }),
+}

--- a/vale/Makefile
+++ b/vale/Makefile
@@ -26,3 +26,8 @@ grafana/vale: dictionaries/en_US-grafana.aff dictionaries/en_US-grafana.dic
 sync: ## Update the vendored Google style.
 sync:
 	cd $(GIT_ROOT) && vale sync
+
+.vale.ini ../.vale.ini: ## Generate Vale INI configuration from the Jsonnet data template.
+.vale.ini ../.vale.ini: .vale.jsonnet
+	jsonnet -Se "(import '.vale.jsonnet').container" | sed '$${/^$$/d;}' > .vale.ini
+	jsonnet -Se "(import '.vale.jsonnet').repository" | sed '$${/^$$/d;}' > ../.vale.ini


### PR DESCRIPTION
@moxious

> In an audit of 63 instances where this vale rule triggered on grafana/grafana, the 30+ I looked at were all incorrect / in contexts that I think ought not have been flagged.

Co-authored-by: David Allen <david.allen@grafana.com>
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
