### PR TITLE
Add Vale in VSCode steps

### DIFF
--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -101,4 +101,3 @@ You can use Vale to lint your current document in VS Code.
    1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.
 
 1. Restart VS Code.
-1. Use the PROBLEMS tab to view the Vale linting for the current file.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -84,7 +84,7 @@ You can use Vale to lint your current document in VS Code.
 
    Replace `FULL_PATH_TO_REPO` with the full path to the Technical Documentation repository. For example, `/home/user/git-repos`.
 
-1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VSCode.
+1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VS Code.
 
    1. Start VS Code.
    1. Press Ctrl+P, paste the following command, and press enter.
@@ -103,4 +103,4 @@ You can use Vale to lint your current document in VS Code.
 
 1. Restart VS Code.
 
-You can use the **PROBLEMS** tab (Ctrl_Shift+M) to view the Vale linting for the current file.
+You can use the **PROBLEMS** tab to view the Vale linting for the current file.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -115,8 +115,8 @@ You can use Vale to lint your current document in VS Code.
 
    1. Press Ctrl+Shift+X or click the **Extensions** icon and select the Vale VS Code extension.
    1. Select the gear icon.
-   1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
-   1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
+   1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
+   1. Set **Vale › Vale CLI: Path** to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
 
 1. Restart VS Code.
 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -64,6 +64,12 @@ The task title contains a verb and an object. For example: "Create a dashboard".
 
 You can use Vale to lint your current document in VS Code.
 
+### Before you begin
+
+Install [Homebrew](https://brew.sh/) on macOS.
+
+### Install and configure Vale in VS Code
+
 1. Clone the [Writer's Toolkit](https://github.com/grafana/writers-toolkit/) repository.
 
    ```bash
@@ -73,8 +79,8 @@ You can use Vale to lint your current document in VS Code.
 1. Download and install [Vale](https://vale.sh/docs/vale-cli/installation/).
 
    {{% admonition type="note" %}}
-   Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
-   You can use your Linux package manager to install Vale if it is included in your distribution repositories.
+   Refer to the Linux command line installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
+   You can also use your Linux package manager to install Vale.
    {{% /admonition %}}
 
    {{< code >}}

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -59,3 +59,47 @@ The task title contains a verb and an object. For example: "Create a dashboard".
 
 <!-- vale Grafana.Quotes = YES -->
 ```
+
+## Use Vale in VSCode
+
+You can use Vale to lint your current document in VScode.
+
+1. Clone the [Techncial Documentation](https://github.com/grafana/technical-documentation) repository.
+
+   ```bash
+   git clone git@github.com:grafana/technical-documentation.git
+   ```
+
+1. Download [Vale](https://github.com/errata-ai/vale/releases).
+1. Extract the downloaded zip file to `$HOME/vale`.
+1. Create a `vale.ini` in `$HOME/vale` with the following contents:
+
+   ```bash
+   StylesPath = /FULL_PATH_TO_REPO/technical-documentation/linters/vale
+   MinAlertLevel = suggestion
+
+   [*.md]
+   BasedOnStyles = Grafana
+   ```
+
+   Replace `FULL_PATH_TO_REPO` with the full path to the Techncial Documentation repository. For example, `/home/user/git-repos`.
+
+1. Install the [ValeVSCode extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VSCode.
+
+   1. Start VS Code.
+   1. Press Ctrl+P, paste the following command, and press enter.
+
+   ```
+   ext install ChrisChinchilla.vale-vscode
+   ```
+
+1. Configure the Vale VS Code extension.
+   1. Press Ctrl+Shift+X.
+   1. Select the Vale VSCode extension.
+   1. Select the gear icon.
+   1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, `/home/user/vale/vale.ini`.
+   1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.
+
+1. Restart VS Code.
+
+You can use the **PROBLEMS** tab (Ctrl_Shift+M) to view the Vale linting for the current file. 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -67,7 +67,7 @@ You can use Vale to lint your current document in VS Code.
 1. Clone the [Writer's Toolkit](https://github.com/grafana/writers-toolkit/) repository.
 
    ```bash
-   git clone git@github.com:grafana/technical-documentation.git
+   git clone git@github.com:grafana/writers-toolkit.git
    ```
 
 1. Download and install [Vale](https://github.com/errata-ai/vale/releases).

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -74,6 +74,8 @@ You can use Vale to lint your current document in VS Code.
 
    {{% admonition type="note" %}}
    Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
+   
+   You can use your Linux package manager to install Vale if it is included in your distribution repositories.
    {{% /admonition %}}
 
    {{< code >}}

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -60,11 +60,11 @@ The task title contains a verb and an object. For example: "Create a dashboard".
 <!-- vale Grafana.Quotes = YES -->
 ```
 
-## Use Vale in VSCode
+## Use Vale in VS Code
 
-You can use Vale to lint your current document in VScode.
+You can use Vale to lint your current document in VS Code.
 
-1. Clone the [Techncial Documentation](https://github.com/grafana/technical-documentation) repository.
+1. Clone the [Technical Documentation](https://github.com/grafana/technical-documentation) repository.
 
    ```bash
    git clone git@github.com:grafana/technical-documentation.git
@@ -82,9 +82,9 @@ You can use Vale to lint your current document in VScode.
    BasedOnStyles = Grafana
    ```
 
-   Replace `FULL_PATH_TO_REPO` with the full path to the Techncial Documentation repository. For example, `/home/user/git-repos`.
+   Replace `FULL_PATH_TO_REPO` with the full path to the Technical Documentation repository. For example, `/home/user/git-repos`.
 
-1. Install the [ValeVSCode extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VSCode.
+1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VSCode.
 
    1. Start VS Code.
    1. Press Ctrl+P, paste the following command, and press enter.
@@ -94,12 +94,13 @@ You can use Vale to lint your current document in VScode.
    ```
 
 1. Configure the Vale VS Code extension.
+
    1. Press Ctrl+Shift+X.
-   1. Select the Vale VSCode extension.
+   1. Select the Vale VS Code extension.
    1. Select the gear icon.
    1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, `/home/user/vale/vale.ini`.
    1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.
 
 1. Restart VS Code.
 
-You can use the **PROBLEMS** tab (Ctrl_Shift+M) to view the Vale linting for the current file. 
+You can use the **PROBLEMS** tab (Ctrl_Shift+M) to view the Vale linting for the current file.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -115,7 +115,7 @@ You can use Vale to lint your current document in VS Code.
 
    1. Press Ctrl+Shift+X or click the **Extensions** icon and select the Vale VS Code extension.
    1. Select the gear icon.
-<!-- vale off -->
+   <!-- vale off -->
    1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
 <!-- vale on -->
    1. Set **Vale › Vale CLI: Path** to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -113,7 +113,7 @@ You can use Vale to lint your current document in VS Code.
 
 1. Configure the Vale VS Code extension.
 
-   1. Press Ctrl+Shift+X and select the Vale VS Code extension.
+   1. Press Ctrl+Shift+X or click the **Extensions** icon and select the Vale VS Code extension.
    1. Select the gear icon.
    1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
    1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -115,7 +115,7 @@ Install [Homebrew](https://brew.sh/) on macOS.
 1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VS Code.
 
    1. Start VS Code.
-   1. Press Ctrl+P, paste the following command, and press Enter.
+   1. Press Ctrl+P, paste the following command, and press Enter. Alternatively, click the **Extensions** icon, search for "Vale VS Code", open it, and click "Install".
 
    ```
    ext install ChrisChinchilla.vale-vscode

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -100,7 +100,7 @@ You can use Vale to lint your current document in VS Code.
    Google.Quotes = NO
    Google.Units = NO
    Google.WordList = NO
-   TokenIgnores = (<http[^\n]+>+?)
+   TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
    ```
 
    Replace `FULL_PATH_TO_REPO` with the full path to the cloned Writer's Toolkit repository. For example, in Linux you could set StylesPath to `/home/username/git-repos/writers-toolkit/vale` and in macOS, you could set it to `/Users/username/git-repos/writers-toolkit/vale`. The path depends on where you cloned the git repository.
@@ -127,5 +127,5 @@ You can use Vale to lint your current document in VS Code.
 
 Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
 
-- In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
-- A full report in the **PROBLEMS** tab. These errors include a reference to the Vale rule.
+- In-line edit marks. You can hover your mouse cursor over the edit marks to view the Vale warning or error.
+- A full report in the **PROBLEMS** tab. Each Vale warning or error in the report includes the line and column where the error occurs.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -115,7 +115,9 @@ You can use Vale to lint your current document in VS Code.
 
    1. Press Ctrl+Shift+X or click the **Extensions** icon and select the Vale VS Code extension.
    1. Select the gear icon.
+<!-- vale off -->
    1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
+<!-- vale on -->
    1. Set **Vale › Vale CLI: Path** to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
 
 1. Restart VS Code.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -103,7 +103,7 @@ You can use Vale to lint your current document in VS Code.
    TokenIgnores = (<http[^\n]+>+?)
    ```
 
-   Replace `FULL_PATH_TO_REPO` with the full path to the cloned Technical Documentation repository. For example, in Linux you could set StylesPath to `/home/username/git-repos/technical-documentation/linters/vale` and in macOS, you could set it to `/Users/username/git-repos/technical-documentation/linters/vale`. The path depends on where you cloned the git repository.
+   Replace `FULL_PATH_TO_REPO` with the full path to the cloned Writer's Toolkit repository. For example, in Linux you could set StylesPath to `/home/username/git-repos/writers-toolkit/vale` and in macOS, you could set it to `/Users/username/git-repos/writers-toolkit/vale`. The path depends on where you cloned the git repository.
 
 1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VS Code.
 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -70,7 +70,7 @@ You can use Vale to lint your current document in VS Code.
    git clone git@github.com:grafana/technical-documentation.git
    ```
 
-1. Download [Vale](https://github.com/errata-ai/vale/releases).
+1. Download and install [Vale](https://github.com/errata-ai/vale/releases).
 
    {{% admonition type="note" %}}
    Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -120,9 +120,7 @@ You can use Vale to lint your current document in VS Code.
 
    1. Press Ctrl+Shift+X or click the **Extensions** icon and select the Vale VS Code extension.
    1. Select the gear icon.
-   <!-- vale off -->
    1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
-   <!-- vale on -->
    1. For Linux, set **Vale › Vale CLI: Path** to the path for the vale executable. For example, that could be `/home/USERNAME/bin/vale`.
 
 1. Restart VS Code.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -125,4 +125,4 @@ You can use Vale to lint your current document in VS Code.
 Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
 
 - In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
-1. A full report in the **PROBLEMS** tab.
+- A full report in the **PROBLEMS** tab. These errors include a reference to the Vale rule.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -121,7 +121,7 @@ You can use Vale to lint your current document in VS Code.
    <!-- vale off -->
    1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
    <!-- vale on -->
-   1. Set **Vale › Vale CLI: Path** to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
+   1. For Linux, set **Vale › Vale CLI: Path** to the path for the vale executable. For example, that could be `/home/USERNAME/bin/vale`.
 
 1. Restart VS Code.
 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -74,7 +74,6 @@ You can use Vale to lint your current document in VS Code.
 
    {{% admonition type="note" %}}
    Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
-   
    You can use your Linux package manager to install Vale if it is included in your distribution repositories.
    {{% /admonition %}}
 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -101,5 +101,4 @@ You can use Vale to lint your current document in VS Code.
    1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.
 
 1. Restart VS Code.
-
-You can use the **PROBLEMS** tab to view the Vale linting for the current file.
+1. Use the PROBLEMS tab to view the Vale linting for the current file.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -77,6 +77,7 @@ You can use Vale to lint your current document in VS Code.
    {{% /admonition %}}
 
    {{< code >}}
+
    ```linux
    wget https://github.com/errata-ai/vale/releases/download/v2.28.0/vale_2.28.0_Linux_64-bit.tar.gz
    mkdir bin && tar -xvzf vale_2.28.0_Linux_64-bit.tar.gz -C bin
@@ -86,6 +87,7 @@ You can use Vale to lint your current document in VS Code.
    ```macos
    brew install vale
    ```
+
    {{< /code >}}
 
 1. Create a `vale.ini` file in your home directory or in a working directory with the following contents:

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -70,7 +70,7 @@ You can use Vale to lint your current document in VS Code.
    git clone git@github.com:grafana/writers-toolkit.git
    ```
 
-1. Download and install [Vale](https://github.com/errata-ai/vale/releases).
+1. Download and install [Vale](https://vale.sh/docs/vale-cli/installation/).
 
    {{% admonition type="note" %}}
    Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -124,5 +124,5 @@ You can use Vale to lint your current document in VS Code.
 
 Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
 
-1. In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
+- In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
 1. A full report in the **PROBLEMS** tab.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -117,7 +117,7 @@ You can use Vale to lint your current document in VS Code.
    1. Select the gear icon.
    <!-- vale off -->
    1. Set **Vale › Vale CLI: Config** to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
-<!-- vale on -->
+   <!-- vale on -->
    1. Set **Vale › Vale CLI: Path** to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
 
 1. Restart VS Code.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -93,11 +93,14 @@ You can use Vale to lint your current document in VS Code.
 1. Create a `vale.ini` file in your home directory or in a working directory with the following contents:
 
    ```bash
-   StylesPath = /FULL_PATH_TO_REPO/technical-documentation/linters/vale
    MinAlertLevel = suggestion
-
+   StylesPath = /FULL_PATH_TO_REPO/writers-toolkit/vale
    [*.md]
-   BasedOnStyles = Grafana
+   BasedOnStyles = Google, Grafana
+   Google.Quotes = NO
+   Google.Units = NO
+   Google.WordList = NO
+   TokenIgnores = (<http[^\n]+>+?)
    ```
 
    Replace `FULL_PATH_TO_REPO` with the full path to the cloned Technical Documentation repository. For example, in Linux you could set StylesPath to `/home/username/git-repos/technical-documentation/linters/vale` and in macOS, you could set it to `/Users/username/git-repos/technical-documentation/linters/vale`. The path depends on where you cloned the git repository.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -73,7 +73,7 @@ You can use Vale to lint your current document in VS Code.
 1. Download [Vale](https://github.com/errata-ai/vale/releases).
 
    {{% admonition type="note" %}}
-   Refer to the Linux installation steps at [Github Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
+   Refer to the Linux installation steps at [GitHub Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
    {{% /admonition %}}
 
    {{< code >}}
@@ -120,5 +120,5 @@ You can use Vale to lint your current document in VS Code.
 
 Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
 
-1. In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warnign or error.
-1. A full report in the `PROBLEMS` tab. Press Ctrl + Shift + M to view the `PROBLEMS` tab.
+1. In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
+1. A full report in the `PROBLEMS` tab.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -95,8 +95,7 @@ You can use Vale to lint your current document in VS Code.
 
 1. Configure the Vale VS Code extension.
 
-   1. Press Ctrl+Shift+X.
-   1. Select the Vale VS Code extension.
+   1. Press Ctrl+Shift+X and select the Vale VS Code extension.
    1. Select the gear icon.
    1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, `/home/user/vale/vale.ini`.
    1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -64,7 +64,7 @@ The task title contains a verb and an object. For example: "Create a dashboard".
 
 You can use Vale to lint your current document in VS Code.
 
-1. Clone the [Technical Documentation](https://github.com/grafana/technical-documentation) repository.
+1. Clone the [Writer's Toolkit](https://github.com/grafana/writers-toolkit/) repository.
 
    ```bash
    git clone git@github.com:grafana/technical-documentation.git

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -123,4 +123,4 @@ You can use Vale to lint your current document in VS Code.
 Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
 
 1. In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warning or error.
-1. A full report in the `PROBLEMS` tab.
+1. A full report in the **PROBLEMS** tab.

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -66,7 +66,7 @@ You can use Vale to lint your current document in VS Code.
 
 ### Before you begin
 
-Install [Homebrew](https://brew.sh/) on macOS.
+If you are installing Vale on macOS, make sure that [Homebrew](https://brew.sh/) is installed.
 
 ### Install and configure Vale in VS Code
 

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -71,8 +71,24 @@ You can use Vale to lint your current document in VS Code.
    ```
 
 1. Download [Vale](https://github.com/errata-ai/vale/releases).
-1. Extract the downloaded zip file to `$HOME/vale`.
-1. Create a `vale.ini` in `$HOME/vale` with the following contents:
+
+   {{% admonition type="note" %}}
+   Refer to the Linux installation steps at [Github Releases](https://vale.sh/docs/vale-cli/installation/#github-releases). Verify that you are downloading the latest build of Vale for Linux.
+   {{% /admonition %}}
+
+   {{< code >}}
+   ```linux
+   wget https://github.com/errata-ai/vale/releases/download/v2.28.0/vale_2.28.0_Linux_64-bit.tar.gz
+   mkdir bin && tar -xvzf vale_2.28.0_Linux_64-bit.tar.gz -C bin
+   export PATH=./bin:"$PATH"
+   ```
+
+   ```macos
+   brew install vale
+   ```
+   {{< /code >}}
+
+1. Create a `vale.ini` file in your home directory or in a working directory with the following contents:
 
    ```bash
    StylesPath = /FULL_PATH_TO_REPO/technical-documentation/linters/vale
@@ -82,12 +98,12 @@ You can use Vale to lint your current document in VS Code.
    BasedOnStyles = Grafana
    ```
 
-   Replace `FULL_PATH_TO_REPO` with the full path to the Technical Documentation repository. For example, `/home/user/git-repos`.
+   Replace `FULL_PATH_TO_REPO` with the full path to the cloned Technical Documentation repository. For example, in Linux you could set StylesPath to `/home/username/git-repos/technical-documentation/linters/vale` and in macOS, you could set it to `/Users/username/git-repos/technical-documentation/linters/vale`. The path depends on where you cloned the git repository.
 
 1. Install the [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) in VS Code.
 
    1. Start VS Code.
-   1. Press Ctrl+P, paste the following command, and press enter.
+   1. Press Ctrl+P, paste the following command, and press Enter.
 
    ```
    ext install ChrisChinchilla.vale-vscode
@@ -97,7 +113,12 @@ You can use Vale to lint your current document in VS Code.
 
    1. Press Ctrl+Shift+X and select the Vale VS Code extension.
    1. Select the gear icon.
-   1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, `/home/user/vale/vale.ini`.
-   1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, `/home/user/vale/vale`.
+   1. Set `Vale › Vale CLI: Config` to the path to your `vale.ini` file. For example, on Linux that could be `/home/USERNAME/vale.ini` and on macOS, that could be `/Users/USERNAME/vale.ini`. The path depends on where you created the `vale.ini` file.
+   1. Set `Vale › Vale CLI: Path` to the path for the vale executable. For example, in Linux, that could be `/home/USERNAME/bin/vale` and on macOS, that could be `/usr/local/bin/vale`.
 
 1. Restart VS Code.
+
+Vale lints your current document every time you save your changes. The extension reports the linting results in two ways:
+
+1. In-line edit marks. You can hover your mouse cursor over the edit marks to view the vale warnign or error.
+1. A full report in the `PROBLEMS` tab. Press Ctrl + Shift + M to view the `PROBLEMS` tab.


### PR DESCRIPTION
Adding steps to install and configure Vale for VSCode. This will enable Vale linting on the current topic open in VSCode. Vale linting is done at each save. The Vale output is shown in the PROBLEMS tab in VSCode.