### PR TITLE
Ignore the inline token representing bold emphasis

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,4 +6,4 @@ BasedOnStyles = Google, Grafana
 Google.Quotes = NO
 Google.Units = NO
 Google.WordList = NO
-TokenIgnores = (<http[^\n]+>+?)
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*

--- a/vale/.vale.ini
+++ b/vale/.vale.ini
@@ -6,4 +6,4 @@ BasedOnStyles = Google, Grafana
 Google.Quotes = NO
 Google.Units = NO
 Google.WordList = NO
-TokenIgnores = (<http[^\n]+>+?)
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*

--- a/vale/.vale.jsonnet
+++ b/vale/.vale.jsonnet
@@ -16,7 +16,7 @@
         'Google.WordList': 'NO',
 
         // https://github.com/errata-ai/vale/issues/288
-        TokenIgnores: @'(<http[^\n]+>+?)',
+        TokenIgnores: @'(<http[^\n]+>+?), \*\*[^\n]+\*\*',
       },
     },
   },

--- a/vale/Makefile
+++ b/vale/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-builtin-rule
 .PHONY: help
 help: ## Display this help
 help:
-	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/%]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/% ]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 PODMAN := $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 GIT_ROOT := $(shell git rev-parse --show-toplevel)


### PR DESCRIPTION
Means that writers no longer have to worry about spell checking in bold text which is used in our style to represent UI elements which are frequently spelled using non dictionary words.

To test, checkout this branch in VSCode configured with Vale and typo something in bold text like the following:

```markdown
_Seplling mistkae_
`Seplling mistkae`
**Seplling mistkae**
```

Note that Vale style applies rules to italic emphasis.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
