### PR TITLE
Remove indent from code block inner to make it copy-pastable and add note about `prettier`

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -58,47 +58,52 @@ The `code` shortcode provides the ability to show multiple snippets of code in d
 
 ### Example
 
-<!-- The code blocks below are indented to prevent hugo rendering  -->
+{{% admonition type="note" %}}
+If your repository uses `prettier` to format the files, use the HTML comments `&lt;!-- prettier-ignore-start --&gt;` and `&lt;!-- prettier-ignore-end --&gt;` around the shortcode tags to ensure correct rendering.
+{{% /admonition %}}
 
 <!-- prettier-ignore-start -->
-```markdown
+
+````markdown
 {{</* code */>}}
-    ```bash
-    curl "https://your-stack.grafana.net/api/plugins/grafana-incident-app/resources/api/v1/ActivityService.AddActivity"
-    ```
 
-    ```go
-    package main
-
-    import (
-      "context"
-    )
-
-    func main() {
-
-      ...
-    ```
-
-    ```javascript
-    import { GrafanaIncidentClient, ActivityService } from '@grafana/incident-node';
-
-    // https://grafana.com/docs/grafana-cloud/incident/api/auth/#get-a-service-account-token
-    const serviceAccountToken = process.env.GRAFANA_CLOUD_SERVICE_ACCOUNT_TOKEN;
-    const client = new GrafanaIncidentClient(
-      "https://your-stack.grafana.net",
-      serviceAccountToken
-    );
-
-    ...
-    ```
-
-    ```json
-    POST https://your-stack.grafana.net/api/plugins/grafana-incident-app/resources/api/v1/ActivityService.AddActivity
-    Content-Type="application/json; charset=utf-8"
-    Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7F...
-    ```
-{{</* /code */>}}
+```bash
+curl "https://your-stack.grafana.net/api/plugins/grafana-incident-app/resources/api/v1/ActivityService.AddActivity"
 ```
+
+```go
+package main
+
+import (
+  "context"
+)
+
+func main() {
+
+  ...
+```
+
+```javascript
+import { GrafanaIncidentClient, ActivityService } from '@grafana/incident-node';
+
+// https://grafana.com/docs/grafana-cloud/incident/api/auth/#get-a-service-account-token
+const serviceAccountToken = process.env.GRAFANA_CLOUD_SERVICE_ACCOUNT_TOKEN;
+const client = new GrafanaIncidentClient(
+  "https://your-stack.grafana.net",
+  serviceAccountToken
+);
+
+...
+```
+
+```json
+POST https://your-stack.grafana.net/api/plugins/grafana-incident-app/resources/api/v1/ActivityService.AddActivity
+Content-Type="application/json; charset=utf-8"
+Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7F...
+```
+
+{{</* /code */>}}
+````
 <!-- prettier-ignore-end -->
 
 ## `docs/experimental-deployment` shortcode


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
