### PR TITLE
Add "allows to" rule explainer

### DIFF
--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -134,3 +134,17 @@ Vale lints your current document every time you save your changes. The extension
 
 - In-line edit marks. You can hover your mouse cursor over the edit marks to view the Vale warning or error.
 - A full report in the **PROBLEMS** tab. Each Vale warning or error in the report includes the line and column where the error occurs.
+
+## Errata for Vale
+
+When you write something that has an associated rule in one of the Vale linting files, an error is generated, such as:
+
+`Use '%s' instead of '%s'.`
+
+`Did you mean '%s' instead of '%s'?`
+
+Most of these error messages and suggestions are self-explanatory and include preferred spellings or alternate words. However, the following rules require further explanation:
+
+### Allowsto
+
+Common wording error. The linter suggests replacing "allows to" to with the grammatically correct "allows you to", since there is no use case for the phrase "allows to."

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -145,6 +145,6 @@ When you write something that has an associated rule in one of the Vale linting 
 
 Most of these error messages and suggestions are self-explanatory and include preferred spellings or alternate words. However, the following rules require further explanation:
 
-### Allowsto
+### Allows to
 
 Common wording error. The linter suggests replacing "allows to" to with the grammatically correct "allows you to", since there is no use case for the phrase "allows to."


### PR DESCRIPTION
Adds an Errata section for the Vale linter and adds a specific section to explain the "allows to" rule.

For some reason, when I build this locally, the right sidebar renders at the bottom of the page, but it's also doing this on the original PR.