### PR TITLE
Add sub-headings to shared content page

### DIFF
--- a/docs/sources/write/reuse-content/reuse-shared-content/index.md
+++ b/docs/sources/write/reuse-content/reuse-shared-content/index.md
@@ -31,8 +31,8 @@ To reuse shared content, follow these steps:
    - When sharing content within a single project, that project is both the sharing and consuming project.
 
    - However, when sharing content from one project to another then you must choose which is the sharing project and which is the consuming project.
-   Because we rely on external contributions, sharing from open-source projects is preferred.
-   For example, when sharing content between Tempo and Grafana Enterprise Traces, prefer Tempo to be the sharing project and Grafana Enterprise Traces to be the consuming project.
+     Because we rely on external contributions, sharing from open-source projects is preferred.
+     For example, when sharing content between Tempo and Grafana Enterprise Traces, prefer Tempo to be the sharing project and Grafana Enterprise Traces to be the consuming project.
 
 1. In the sharing project, create the `docs/sources/shared/` directory if it does not exist.
 

--- a/docs/sources/write/reuse-content/reuse-shared-content/index.md
+++ b/docs/sources/write/reuse-content/reuse-shared-content/index.md
@@ -22,17 +22,17 @@ This topic describes how to extract and share a chunk of content to multiple pag
 
 ## Steps
 
-To reuse shared content:
+To reuse shared content, follow these steps:
+
+### Create a shared directory
 
 1. Identify the sharing and consuming projects.
 
-   When sharing content within a single project, that project is both the sharing and consuming project.
+   - When sharing content within a single project, that project is both the sharing and consuming project.
 
-   However, when sharing content from one project to another then you must choose which is the sharing project and which is the consuming project.
+   - However, when sharing content from one project to another then you must choose which is the sharing project and which is the consuming project.
    Because we rely on external contributions, sharing from open-source projects is preferred.
    For example, when sharing content between Tempo and Grafana Enterprise Traces, prefer Tempo to be the sharing project and Grafana Enterprise Traces to be the consuming project.
-
-### Create a shared directory
 
 1. In the sharing project, create the `docs/sources/shared/` directory if it does not exist.
 

--- a/docs/sources/write/reuse-content/reuse-shared-content/index.md
+++ b/docs/sources/write/reuse-content/reuse-shared-content/index.md
@@ -32,6 +32,8 @@ To reuse shared content:
    Because we rely on external contributions, sharing from open-source projects is preferred.
    For example, when sharing content between Tempo and Grafana Enterprise Traces, prefer Tempo to be the sharing project and Grafana Enterprise Traces to be the consuming project.
 
+### Create a shared directory
+
 1. In the sharing project, create the `docs/sources/shared/` directory if it does not exist.
 
 1. In the sharing project, create the file `docs/sources/shared/index.md` if it does not exist, with the following contents:
@@ -54,6 +56,8 @@ To reuse shared content:
 
    0 directories, 1 file
    ```
+
+### Create a shared file
 
 1. In the sharing project, create a file for the shared content in the `docs/sources/shared/` directory.
 


### PR DESCRIPTION
When I'm using the directions on the [Reuse shared content](https://grafana.com/docs/writers-toolkit/write/reuse-content/reuse-shared-content/) page, I'm almost always adding a single file in an existing `shared` directory, not adding the directory. As a result, I'm always looking for the spot where those directions begin, halfway through the steps. This PR adds sub-headings to the page to delineate the creation of the directory from the creation of the file. 