### PR TITLE
Add optional featureFlag parameter for public-preview shortcode

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -205,12 +205,12 @@ The `docs/public-preview` shortcode produces a note admonition with the preferre
 | `featureFlag` | The name of the feature flag users use to enable the product or feature. | yes      |
 
 ```markdown
-{{</* docs/public-preview-toggle product="experimental-feature" featureFlag="its-feature-flag" */>}}
+{{</* docs/public-preview-toggle product="public-preview-feature" featureFlag="its-feature-flag" */>}}
 ```
 
 Produces:
 
-{{< docs/public-preview-toggle product="experimental-feature" featureFlag="its-feature-flag" >}}
+{{< docs/public-preview-toggle product="public-preview-feature" featureFlag="its-feature-flag" >}}
 
 ## `docs/shared` shortcode
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -183,9 +183,10 @@ Produces:
 
 The `docs/public-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in public preview.
 
-| Parameter | Description                         | Required |
-| --------- | ----------------------------------- | -------- |
-| `product` | The name of the product or feature. | yes      |
+| Parameter     | Description                                                              | Required |
+| ------------- | ------------------------------------------------------------------------ | -------- |
+| `product`     | The name of the product or feature.                                      | yes      |
+| `featureFlag` | The name of the feature flag users use to enable the product or feature. | no      |
 
 ```markdown
 {{</* docs/public-preview product="public-preview-feature" */>}}
@@ -195,22 +196,13 @@ Produces:
 
 {{< docs/public-preview product="public-preview-feature" >}}
 
-## `docs/public-preview-toggle` shortcode
-
-The `docs/public-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in public preview.
-
-| Parameter     | Description                                                              | Required |
-| ------------- | ------------------------------------------------------------------------ | -------- |
-| `product`     | The name of the product or feature.                                      | yes      |
-| `featureFlag` | The name of the feature flag users use to enable the product or feature. | yes      |
-
 ```markdown
-{{</* docs/public-preview-toggle product="public-preview-feature" featureFlag="its-feature-flag" */>}}
+{{</* docs/public-preview product="public-preview-feature" featureFlag="its-feature-flag" */>}}
 ```
 
 Produces:
 
-{{< docs/public-preview-toggle product="public-preview-feature" featureFlag="its-feature-flag" >}}
+{{< docs/public-preview product="public-preview-feature" featureFlag="its-feature-flag" >}}
 
 ## `docs/shared` shortcode
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -195,6 +195,23 @@ Produces:
 
 {{< docs/public-preview product="public-preview-feature" >}}
 
+## `docs/public-preview-toggle` shortcode
+
+The `docs/public-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in public preview.
+
+| Parameter     | Description                                                              | Required |
+| ------------- | ------------------------------------------------------------------------ | -------- |
+| `product`     | The name of the product or feature.                                      | yes      |
+| `featureFlag` | The name of the feature flag users use to enable the product or feature. | yes      |
+
+```markdown
+{{</* docs/public-preview-toggle product="experimental-feature" featureFlag="its-feature-flag" */>}}
+```
+
+Produces:
+
+{{< docs/public-preview-toggle product="experimental-feature" featureFlag="its-feature-flag" >}}
+
 ## `docs/shared` shortcode
 
 The `docs/shared` shortcode lets you reuse content across the Grafana website by including shared pages from source content repositories. The source content repository must explicitly share the page by placing it into its `shared` directory.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -186,7 +186,7 @@ The `docs/public-preview` shortcode produces a note admonition with the preferre
 | Parameter     | Description                                                              | Required |
 | ------------- | ------------------------------------------------------------------------ | -------- |
 | `product`     | The name of the product or feature.                                      | yes      |
-| `featureFlag` | The name of the feature flag users use to enable the product or feature. | no      |
+| `featureFlag` | The name of the feature flag users use to enable the product or feature. | no       |
 
 ```markdown
 {{</* docs/public-preview product="public-preview-feature" */>}}


### PR DESCRIPTION
Adds option/guidance for adding a `featureFlag` parameter/argument for the public-preview shortcode

Do not attempt to merge until the actual work on the website has been done. Raised on [issue 15642](https://github.com/grafana/website/issues/15642)