### PR TITLE
Make headings plain text

### DIFF
--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -45,9 +45,9 @@ weight: 100
 
 The following headings describe what each element does and provides guidelines for its content.
 
-### `aliases`
+### Aliases
 
-Use to create redirects from the previous URL to the new URL when a page changes or moves.
+Use `aliases` to create redirects from the previous URL to the new URL when a page changes or moves.
 As a best practice, when you rename or move files, you should create an alias with a reference to the previous URL path to create a redirect from the old URL to the new URL.
 In some cases, for example when you have deleted content or split a file into multiple topics, it may not be possible to create an alias for the moved content.
 
@@ -131,9 +131,9 @@ To test an alias results in the correct redirect, use your browser or a command-
 
 1. Confirm that the value of the `destination` `const` in the `<script>` tag is the pretty URL for the page with the alias.
 
-### `date`
+### Date
 
-Describes the initial publish date of the page.
+`date` describes the initial publish date of the page.
 Hugo produces XML page outputs for use by RSS feeds where users can be notified of updates.
 Customers use RSS feeds of release notes pages to be notified of new releases.
 Therefore, the `date` front matter is recommended for release note pages.
@@ -144,9 +144,9 @@ For example, `date: "2023-04-24T00:00:00Z"` is 12:00 AM, Apr 24 Coordinated Univ
 The `date` front matter also impacts menu ordering.
 Pages with more recent dates are lower in the menu.
 
-### `description` (required)
+### Description (required)
 
-Use to provide the short description of the topic to search engines, including the search engine used in the Grafana documentation site. The description is also displayed on social media, such as Twitter, to provide a clue to users about the page contents.
+Use `description` to provide the short description of the topic to search engines, including the search engine used in the Grafana documentation site. The description is also displayed on social media, such as Twitter, to provide a clue to users about the page contents.
 
 The number of characters vary by media, so make the description concise.
 Provide enough information to guide users to the content by describing what content the link leads to.
@@ -154,19 +154,19 @@ Often, this doesn’t need to be original text, you can often scan the first few
 If it's too long, it is harmlessly truncated on social media.
 Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
-### `draft`
+### Draft
 
-When set to `true`, this option prevents Hugo from rendering the content.
+When `draft` is set to `true`, this option prevents Hugo from rendering the content.
 Use the command-line flag `--buildDrafts` to generate content marked as `draft: true`.
 
-### `keywords`
+### Keywords
 
-The website uses keywords to generate links to related pages in the _Related content_ sections.
+The website uses `keywords` to generate links to related pages in the _Related content_ sections.
 They do not appear in the resulting HTML source for the page and do not affect search engine optimization (SEO).
 
 Ideally, use single terms as opposed to phrases.
 
-### `labels`
+### Labels
 
 Use the `labels` key to add one or more values that you want to appear before the topic title on the published page.
 Only certain labels are supported.
@@ -205,11 +205,11 @@ cascade:
       - cloud
 ```
 
-### `menuTitle`
+### MenuTitle
 
-Use to specify a different heading in the sidebar navigation than the `title` element; for example, if you want to abbreviate the topic heading in the table of contents.
+Use `menuTitle` to specify a different heading in the sidebar navigation than the `title` element; for example, if you want to abbreviate the topic heading in the table of contents.
 
-### `title` (required)
+### Title (required)
 
 Hugo uses the `title` to generate the sidebar table of contents if there is no `menuTitle` specified in the front matter. If the `doc-validator` linter has been implemented on your repository, your topic heading must exactly match the title in the metadata.
 
@@ -217,7 +217,7 @@ The `title` becomes the document title element in the HTML. Often, browsers disp
 
 Optimize the title for search engines. Use double quotes (`"`) to surround the title. Do not use smart quotes.
 
-### `weight`
+### Weight
 
 By default, topics are displayed in alphabetical order by `title`.
 

--- a/docs/sources/write/markdown-guide/index.md
+++ b/docs/sources/write/markdown-guide/index.md
@@ -198,7 +198,7 @@ Include images in a document using the following syntax:
 
 This follows the format `![alt text](URL)`.
 
-Alternatively, you can use the [figure shortcode]({{< relref "../shortcodes#figure-shortcode" >}}) if you need more image options, such as adding captions or controlling the image size.
+Alternatively, you can use the [figure shortcode]({{< relref "../shortcodes#figure" >}}) if you need more image options, such as adding captions or controlling the image size.
 
 Within Markdown, HTML is valid, but should be used sparingly:
 

--- a/docs/sources/write/references/index.md
+++ b/docs/sources/write/references/index.md
@@ -33,7 +33,7 @@ All of the following destinations link https://grafana.com/docs/grafana/latest/ 
 
 1. If the source is reused as described in [Reuse directories of content with Hugo mounts]({{< relref "../reuse-content/reuse-directories" >}}), use the `docs/reference` shortcode.
 
-   For more information about the `docs/reference` shortcode, refer to [`docs/reference` shortcode]({{< relref "../shortcodes#docsreference-shortcode" >}}).
+   For more information about the `docs/reference` shortcode, refer to [`docs/reference` shortcode]({{< relref "../shortcodes#docsreference" >}}).
 
 1. If the destination is part of the current documentation set, use the `relref` shortcode.
 

--- a/docs/sources/write/reuse-content/reuse-shared-content/index.md
+++ b/docs/sources/write/reuse-content/reuse-shared-content/index.md
@@ -88,7 +88,7 @@ To reuse shared content, follow these steps:
    {{</* docs/shared source="tempo" lookup="common-introduction.md" version="latest" */>}}
    ```
 
-   For more information about the `docs/shared` shortcode parameters, refer to [docs/shared shortcode]({{< relref "../../shortcodes#docsshared-shortcode" >}}).
+   For more information about the `docs/shared` shortcode parameters, refer to [docs/shared shortcode]({{< relref "../../shortcodes#docsshared" >}}).
 
 1. Verify the include.
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -26,7 +26,7 @@ The Grafana shortcode templates are defined in the `layouts/shortcodes` folder o
 To request custom shortcodes, [create an issue](https://github.com/grafana/writers-toolkit/issues).
 {{% /admonition %}}
 
-## Admonition { #admonition-shortcode }
+## Admonition
 
 The `admonition` shortcode renders its content in a blockquote or stylized banner.
 The style depends on the admonition type as defined in Writers' Toolkit [Style conventions]({{< relref "../style-guide/style-conventions" >}}).
@@ -52,7 +52,7 @@ Kingston is the capital of Jamaica.
 {{%/* /admonition */%}}
 ```
 
-## Code { #code-shortcode }
+## Code
 
 The `code` shortcode provides the ability to show multiple snippets of code in different languages. When a language is selected, other code blocks on the page are toggled if the language is included. The selected language is saved to browser and persists across navigation.
 
@@ -106,7 +106,7 @@ Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7F...
 ````
 <!-- prettier-ignore-end -->
 
-## Collapse { #collapse-shortcode }
+## Collapse
 
 The `collapse` shortcode toggles visibility of sections of content, often helpful when hiding and showing large amounts of content.
 
@@ -128,7 +128,7 @@ Produces:
 Kingston is the capital of Jamaica.
 {{< /collapse >}}
 
-## Docs/experimental-deployment { #docsexperimental-deployment-shortcode }
+## Docs/experimental-deployment
 
 The `docs/experimental-deployment` shortcode produces a note admonition with the preferred copy for explaining that the described deployment is experimental.
 
@@ -144,7 +144,7 @@ Produces:
 
 {{< docs/experimental-deployment >}}
 
-## Docs/experimental { #docsexperimental-shortcode }
+## Docs/experimental
 
 The `docs/experimental` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is experimental.
 
@@ -163,7 +163,7 @@ Produces:
 
 {{< docs/experimental product="experimental-feature" featureFlag="its-feature-flag" >}}
 
-## Docs/private-preview { #docsprivate-preview-shortcode }
+## Docs/private-preview
 
 The `docs/private-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in private preview.
 
@@ -179,7 +179,7 @@ Produces:
 
 {{< docs/private-preview product="private-preview-feature" >}}
 
-## Docs/public-preview { #docspublic-preview-shortcode }
+## Docs/public-preview
 
 The `docs/public-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in public preview.
 
@@ -204,7 +204,7 @@ Produces:
 
 {{< docs/public-preview product="public-preview-feature" featureFlag="its-feature-flag" >}}
 
-## Docs/shared { #docsshared-shortcode }
+## Docs/shared
 
 The `docs/shared` shortcode lets you reuse content across the Grafana website by including shared pages from source content repositories. The source content repository must explicitly share the page by placing it into its `shared` directory.
 
@@ -241,7 +241,7 @@ Headings are offset by one level, so if the source content contains an `h1`, the
 {{</* docs/shared lookup="shared-page.md" source="enterprise-metrics" version="<GEM VERSION>" leveloffset="+1" */>}}
 ```
 
-## Figure { #figure-shortcode }
+## Figure
 
 The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic Markdown to add images]({{< relref "../markdown-guide#images" >}}).
 
@@ -274,7 +274,7 @@ In this example, the image's display size is changed to have a maximum width of 
 {{</* figure max-width="50%" src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
 ```
 
-## Responsive-table { #responsive-table-shortcode }
+## Responsive-table
 
 The `responsive-table` shortcode wraps the table within the shortcode tags with a class that makes the table responsive to the browser window.
 This results in a table with horizontal scrolling that is fixed to the width of the containing element.
@@ -291,7 +291,7 @@ Without the `responsive-table` shortcode, a table can often overflow its contain
 {{%/* /responsive-table */%}}
 ```
 
-## Section { #section-shortcode }
+## Section
 
 The `section` shortcode renders an unordered list of links to a page's child pages. To add a section, insert the `section` shortcode with the following optional parameters:
 
@@ -316,7 +316,7 @@ The following shortcode inserts a lists of links to child pages and includes the
 {{</* section withDescriptions="true"*/>}}
 ```
 
-## Term { #term-shortcode }
+## Term
 
 The `term` shortcode enables a tooltip when a user hovers above text surrounded by the shortcode.
 
@@ -342,7 +342,7 @@ If you are a Grafana Labs employee and want to make changes, edit [`glossary.yam
 For terms with multiple definitions, follow the common dictionary practice of numbering each alternative.
 For an example, refer to the definition of [graph](https://www.dictionary.com/browse/graph).
 
-## Docs/reference { #docs-reference-shortcode }
+## Docs/reference
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo built-in `relref` shortcode.
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -26,7 +26,7 @@ The Grafana shortcode templates are defined in the `layouts/shortcodes` folder o
 To request custom shortcodes, [create an issue](https://github.com/grafana/writers-toolkit/issues).
 {{% /admonition %}}
 
-## `admonition` shortcode
+## Admonition {{#admonition-shortcode}}
 
 The `admonition` shortcode renders its content in a blockquote or stylized banner.
 The style depends on the admonition type as defined in Writers' Toolkit [Style conventions]({{< relref "../style-guide/style-conventions" >}}).
@@ -52,7 +52,7 @@ Kingston is the capital of Jamaica.
 {{%/* /admonition */%}}
 ```
 
-## `code` shortcode
+## Code {{#code-shortcode}}
 
 The `code` shortcode provides the ability to show multiple snippets of code in different languages. When a language is selected, other code blocks on the page are toggled if the language is included. The selected language is saved to browser and persists across navigation.
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -26,7 +26,7 @@ The Grafana shortcode templates are defined in the `layouts/shortcodes` folder o
 To request custom shortcodes, [create an issue](https://github.com/grafana/writers-toolkit/issues).
 {{% /admonition %}}
 
-## Admonition {{#admonition-shortcode}}
+## Admonition { #admonition-shortcode }
 
 The `admonition` shortcode renders its content in a blockquote or stylized banner.
 The style depends on the admonition type as defined in Writers' Toolkit [Style conventions]({{< relref "../style-guide/style-conventions" >}}).
@@ -52,7 +52,7 @@ Kingston is the capital of Jamaica.
 {{%/* /admonition */%}}
 ```
 
-## Code {{#code-shortcode}}
+## Code { #code-shortcode }
 
 The `code` shortcode provides the ability to show multiple snippets of code in different languages. When a language is selected, other code blocks on the page are toggled if the language is included. The selected language is saved to browser and persists across navigation.
 
@@ -106,7 +106,7 @@ Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7F...
 ````
 <!-- prettier-ignore-end -->
 
-## `collapse` shortcode
+## Collapse { #collapse-shortcode }
 
 The `collapse` shortcode toggles visibility of sections of content, often helpful when hiding and showing large amounts of content.
 
@@ -128,7 +128,7 @@ Produces:
 Kingston is the capital of Jamaica.
 {{< /collapse >}}
 
-## `docs/experimental-deployment` shortcode
+## Docs/experimental-deployment { #docsexperimental-deployment-shortcode }
 
 The `docs/experimental-deployment` shortcode produces a note admonition with the preferred copy for explaining that the described deployment is experimental.
 
@@ -144,7 +144,7 @@ Produces:
 
 {{< docs/experimental-deployment >}}
 
-## `docs/experimental` shortcode
+## Docs/experimental { #docsexperimental-shortcode }
 
 The `docs/experimental` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is experimental.
 
@@ -163,7 +163,7 @@ Produces:
 
 {{< docs/experimental product="experimental-feature" featureFlag="its-feature-flag" >}}
 
-## `docs/private-preview` shortcode
+## Docs/private-preview { #docsprivate-preview-shortcode }
 
 The `docs/private-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in private preview.
 
@@ -179,7 +179,7 @@ Produces:
 
 {{< docs/private-preview product="private-preview-feature" >}}
 
-## `docs/public-preview` shortcode
+## Docs/public-preview { #docspublic-preview-shortcode }
 
 The `docs/public-preview` shortcode produces a note admonition with the preferred copy for explaining that the described product or feature is in public preview.
 
@@ -204,7 +204,7 @@ Produces:
 
 {{< docs/public-preview product="public-preview-feature" featureFlag="its-feature-flag" >}}
 
-## `docs/shared` shortcode
+## Docs/shared { #docsshared-shortcode }
 
 The `docs/shared` shortcode lets you reuse content across the Grafana website by including shared pages from source content repositories. The source content repository must explicitly share the page by placing it into its `shared` directory.
 
@@ -241,7 +241,7 @@ Headings are offset by one level, so if the source content contains an `h1`, the
 {{</* docs/shared lookup="shared-page.md" source="enterprise-metrics" version="<GEM VERSION>" leveloffset="+1" */>}}
 ```
 
-## `figure` shortcode
+## Figure { #figure-shortcode }
 
 The `figure` shortcode renders an image with a caption using an HTML [`<figure>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure#usage_notes) element. This shortcode allows you more control over how an image is rendered, but if you don't need these options, you can use [basic Markdown to add images]({{< relref "../markdown-guide#images" >}}).
 
@@ -274,7 +274,7 @@ In this example, the image's display size is changed to have a maximum width of 
 {{</* figure max-width="50%" src="/static/img/docs/grafana-cloud/k8sPods.png" caption="Pod view in Grafana Kubernetes Monitoring" */>}}
 ```
 
-## `responsive-table` shortcode
+## Responsive-table { #responsive-table-shortcode }
 
 The `responsive-table` shortcode wraps the table within the shortcode tags with a class that makes the table responsive to the browser window.
 This results in a table with horizontal scrolling that is fixed to the width of the containing element.
@@ -291,7 +291,7 @@ Without the `responsive-table` shortcode, a table can often overflow its contain
 {{%/* /responsive-table */%}}
 ```
 
-## `section` shortcode
+## Section { #section-shortcode }
 
 The `section` shortcode renders an unordered list of links to a page's child pages. To add a section, insert the `section` shortcode with the following optional parameters:
 
@@ -316,7 +316,7 @@ The following shortcode inserts a lists of links to child pages and includes the
 {{</* section withDescriptions="true"*/>}}
 ```
 
-## `term` shortcode
+## Term { #term-shortcode }
 
 The `term` shortcode enables a tooltip when a user hovers above text surrounded by the shortcode.
 
@@ -342,7 +342,7 @@ If you are a Grafana Labs employee and want to make changes, edit [`glossary.yam
 For terms with multiple definitions, follow the common dictionary practice of numbering each alternative.
 For an example, refer to the definition of [graph](https://www.dictionary.com/browse/graph).
 
-## `docs/reference` shortcode
+## Docs/reference { #docs-reference-shortcode }
 
 The `docs/reference` shortcode offers more flexible linking than the Hugo built-in `relref` shortcode.
 


### PR DESCRIPTION
On the [shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/) and [front matter](https://grafana.com/docs/writers-toolkit/write/front-matter/) pages, the code font in the headings reduces the amount of white space there is between sections and makes the pages hard to scan. Propose taking things out of code font and just capitalizing them since the examples indicate how they should be written/formatted.