### PR TITLE
Fix formatting of `prettier` lint ignore comment

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -59,7 +59,7 @@ The `code` shortcode provides the ability to show multiple snippets of code in d
 ### Example
 
 {{% admonition type="note" %}}
-If your repository uses `prettier` to format the files, use the HTML comments `&lt;!-- prettier-ignore-start --&gt;` and `&lt;!-- prettier-ignore-end --&gt;` around the shortcode tags to ensure correct rendering.
+If your repository uses `prettier` to format the files, use the HTML comments `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` around the shortcode tags to ensure correct rendering.
 {{% /admonition %}}
 
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
Because of the `pre` tags (`` ` ``), the encoded string is being interpreted literally.

Thankfully we can just use the actual HTML comment text and it works as expected.

To test, run `make docs` locally and browse to http://localhost:3002/docs/writers-toolkit/write/shortcodes/#code.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
