### PR TITLE
Add ESLint and Webpack to dictionary

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,5 +1,7 @@
-29
+32
 API/S po:noun
+Datadog/ po:noun
+ESLint/ po:noun
 Goldmark/ po:noun
 Grafana/M po:noun
 OnCall/ po:noun
@@ -11,6 +13,7 @@ SLO/S po:noun
 Splunk/ po:noun
 UI/S po:noun
 URI/S po:noun
+Webpack/ po:noun
 allowlist/S po:noun
 backport/DGS po:verb
 blockquote/S po:noun

--- a/vale/dictionaries/wordlist
+++ b/vale/dictionaries/wordlist
@@ -1,5 +1,6 @@
 API/S po:noun
 Datadog/ po:noun
+ESLint/ po:noun
 Goldmark/ po:noun
 Grafana/M po:noun
 OnCall/ po:noun
@@ -11,6 +12,7 @@ SLO/S po:noun
 Splunk/ po:noun
 UI/S po:noun
 URI/S po:noun
+Webpack/ po:noun
 allowlist/S po:noun
 backport/DGS po:verb
 blockquote/S po:noun


### PR DESCRIPTION
- [ESLint](https://eslint.org/)
- [Webpack](https://webpack.js.org/)

Note that Webpack is stylized as "webpack" in their own documentation but Wikipedia uses "Webpack" -- https://en.wikipedia.org/wiki/Webpack#:~:text=Node.js%20is%20required%20to%20use%20Webpack.

Related to https://github.com/grafana/plugin-tools/pull/484.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
