### PR TITLE
Use "data source plugin" instead of "data-source plugin"

### DIFF
--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -32,6 +32,8 @@ This page is a work in progress.
 
 Also, use _data source plugin_ rather than _data-source plugin_.
 
+While most compound adjectives require a hyphen, we've chosen to leave it out in this case to maintain consistency with the naming data sources in the application and reduce confusion. 
+
 {{% admonition type="note" %}}
 For other compound adjectives, use a hyphen unless otherwise specified.
 {{% /admonition %}}

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -32,6 +32,10 @@ This page is a work in progress.
 
 Also, use _data source plugin_ rather than _data-source plugin_.
 
+{{% admonition type="note" %}}
+For other compound adjectives, use a hyphen unless otherwise specified.
+{{% /admonition %}}
+
 **drop-down** - Use this rather than _dropdown_ or _drop down_.
 
 <!--

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -32,7 +32,7 @@ This page is a work in progress.
 
 Also, use _data source plugin_ rather than _data-source plugin_.
 
-While most compound adjectives require a hyphen, we've chosen to leave it out in this case to maintain consistency with the naming data sources in the application and reduce confusion.
+While most compound adjectives require a hyphen, we've chosen to leave it out in this case to maintain consistency with the naming of data sources in the application and reduce confusion.
 
 {{% admonition type="note" %}}
 For other compound adjectives, use a hyphen unless otherwise specified.

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -30,7 +30,7 @@ This page is a work in progress.
 
 **data source** - Use this rather than _datasource_ for the noun form.
 
-When refering to the plugin specifically, use _data source plugin_ rather than _data-source plugin_.
+Also, use _data source plugin_ rather than _data-source plugin_.
 
 **drop-down** - Use this rather than _dropdown_ or _drop down_.
 

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -30,7 +30,7 @@ This page is a work in progress.
 
 **data source** - Use this rather than _datasource_ for the noun form.
 
-When you need to use the adjective form, use _data-source_ rather than _datasource_.
+When refering to the plugin specifically, use _data source plugin_ rather than _data-source plugin_.
 
 **drop-down** - Use this rather than _dropdown_ or _drop down_.
 

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -32,7 +32,7 @@ This page is a work in progress.
 
 Also, use _data source plugin_ rather than _data-source plugin_.
 
-While most compound adjectives require a hyphen, we've chosen to leave it out in this case to maintain consistency with the naming data sources in the application and reduce confusion. 
+While most compound adjectives require a hyphen, we've chosen to leave it out in this case to maintain consistency with the naming data sources in the application and reduce confusion.
 
 {{% admonition type="note" %}}
 For other compound adjectives, use a hyphen unless otherwise specified.

--- a/vale/Grafana/WordList.yml
+++ b/vale/Grafana/WordList.yml
@@ -59,8 +59,8 @@ swap:
   config file: configuration file
   content type: media type
   curated roles: predefined roles
+  data-?source: data source
   datacenter: data center
-  datasource: data source|data-source
   de-duplicate: deduplicate
   dialog box appears: dialog box opens
   dialog: dialog box


### PR DESCRIPTION
- **data source plugin**: Consistent with our advice to eliminate "datasource" (one word).
- **data-source plugin**: Technically correct as "data source" becomes the adjective.
  Pragmatically, requires a lot of education and changes across all existing documentation and also across the Grafana UI.

> In the end, with Eve and Fiona considering all angles, the decision was not to add the hyphen.

Style roundtable discussion: https://docs.google.com/document/d/1uCjtHEy0lpZggkpgsLDjWwxV9K6h7vcsG2dy4TOS6EA/edit#heading=h.kr6qvkov3k9p.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
