### PR TITLE
Docs: Add disaggregate to Vale linter list of words

### DIFF
--- a/vale/Google/WordList.yml
+++ b/vale/Google/WordList.yml
@@ -46,6 +46,7 @@ swap:
   content type: media type
   curated roles: predefined roles
   data are: data is
+  deaggregate: disaggregate
   Developers Console: Google API Console|API Console
   disabled?: turn off|off
   ephemeral IP address: ephemeral external IP address
@@ -76,6 +77,7 @@ swap:
   tablename: table name
   tablet: device
   touch: tap
+  unaggregate: disaggregate
   url: URL
   vs\.: versus
   World Wide Web: web

--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-51
+52
 Alertmanager/S po:noun
 API/S po:noun
 Datadog/ po:noun
@@ -34,6 +34,7 @@ allowlist/S po:noun
 backport/DGS po:verb
 blockquote/S po:noun
 deliverable/S po:noun
+disaggregate/DS po:verb
 don't/S po:noun
 enablement/ po:noun
 hostname/S po:noun

--- a/vale/dictionaries/wordlist
+++ b/vale/dictionaries/wordlist
@@ -33,6 +33,7 @@ allowlist/S po:noun
 backport/DGS po:verb
 blockquote/S po:noun
 deliverable/S po:noun
+disaggregate/DS po:verb
 don't/S po:noun
 enablement/ po:noun
 hostname/S po:noun


### PR DESCRIPTION
Per @GrafanaWriter, use _disaggregate_ as the antonym of _aggregate_; for example, "disaggregated metrics that have been previously aggregated"

cc @noise, @nickfuzer, @09jvilla, @colega 