### PR TITLE
Add 'Update `make docs` procedure' action

### DIFF
--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -27,7 +27,7 @@ runs:
   - env:
       BRANCH: ${{ inputs.branch }}
       DIRECTORY: ${{ inputs.directory }}
-      GITHUB_TOKEN: ${{ inputs.github_token }}
+      GH_TOKEN: ${{ inputs.token }}
       PR_OPTIONS: ${{ inputs.pr_options }}
     name: Update `make docs` procedure
     run: |

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -48,9 +48,9 @@ runs:
       # commit adds and commits the updated files as the Grafanabot GitHub user.
       function commit {
         git add .
-        git config --local user.email "bot@grafana.com"
-        git config --local user.name "grafanabot"
-        git commit --message "Update \`make docs\` procedure"
+        git config --local user.email bot@grafana.com
+        git config --local user.name grafanabot
+        git commit --message 'Update `make docs` procedure'
       }
 
       PR_STATUS=$(gh pr view "${BRANCH}" --json state --jq .state)
@@ -80,6 +80,6 @@ runs:
       if ! git diff --exit-code; then
         commit
         git push origin "refs/heads/${BRANCH}"
-        gh pr create --fill ${PR_OPTIONS}
+        gh pr create ${PR_OPTIONS} --title  'Update `make docs` procedure' --body ''
       fi
     shell: bash

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -31,34 +31,55 @@ runs:
       PR_OPTIONS: ${{ inputs.pr_options }}
     name: Update `make docs` procedure
     run: |
+      set -euf -o pipefail
+
       if ${{ inputs.trace }}; then
         set -x
       fi
 
-      # If the branch already exists in the remote, the job of the script is to update that branch.
-      # Otherwise, it should create a new branch.
-      if git fetch origin "${BRANCH}"; then
-        git checkout "${BRANCH}"
-      else
-        git checkout -b "${BRANCH}"
-      fi
+      # fetch_files fetches the Makefiles and script and writes them to the provided directory.
+      function fetch_files {
+        local -r directory="$1"
 
-      # Fetch the Makefiles and script.
-      curl -s -Lo "${DIRECTORY}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
-      curl -s -Lo "${DIRECTORY}/make-docs" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
+        curl -s -Lo "${directory}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
+        curl -s -Lo "${directory}/make-docs" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
+      }
 
-      # Add and commit files if there are changes.
-      if ! git diff --exit-code; then
-        # Commit the updated files as the Grafanabot GitHub user.
+      # commit adds and commits the updated files as the Grafanabot GitHub user.
+      function commit {
         git add .
         git config --local user.email "bot@grafana.com"
         git config --local user.name "grafanabot"
         git commit --message "Update \`make docs\` procedure"
-        git push -v origin "refs/heads/${BRANCH}"
+      }
+
+      PR_STATUS=$(gh pr view "${BRANCH}" --json state --jq .state)
+
+      if [[ "${PR_STATUS}" == OPEN ]]; then
+        gh checkout pr "${BRANCH}"
+
+        fetch_files "${DIRECTORY}"
+
+        if ! git diff --exit-code; then
+          commit
+          git push
+        fi
+
+        exit 0
       fi
 
-      # Create a PR if one doesn't already exist.
-      if ! gh pr view "${BRANCH}"; then
+      # Remove the remote branch if it exists because there is no PR associated with it.
+      if git fetch origin "${BRANCH}"; then
+        git push origin --delete "${BRANCH}"
+      fi
+
+      git checkout -b "${BRANCH}"
+
+      fetch_files "${DIRECTORY}"
+
+      if ! git diff --exit-code; then
+        commit
+        git push origin "refs/heads/${BRANCH}"
         gh pr create --fill ${PR_OPTIONS}
       fi
     shell: bash

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -56,7 +56,7 @@ runs:
       PR_STATUS=$(gh pr view "${BRANCH}" --json state --jq .state)
 
       if [[ "${PR_STATUS}" == OPEN ]]; then
-        gh checkout pr "${BRANCH}"
+        gh pr checkout "${BRANCH}"
 
         fetch_files "${DIRECTORY}"
 

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -2,20 +2,25 @@ name: Update `make docs` procedure
 description: This action updates the `make docs` script and related Makefiles.
 inputs:
   branch:
-    description: Name of remote branch to push changes to. Should be unique to avoid conflict with user-created branches.
     default: update-make-docs
+    description: Name of remote branch to push changes to. Should be unique to avoid conflict with user-created branches.
     required: false
   directory:
-    description: Directory within the repository that should contain the script and related Makefiles.
     default: docs
+    description: Directory within the repository that should contain the script and related Makefiles.
     required: false
   pr_options:
     description: Additional command line options provided to the `gh pr create` command.
     required: false
   token:
-    description: Used to open the PR.
     default: ${{ github.token }}
+    description: Used to open the PR.
     required: false
+  trace:
+    default: false
+    description: Print command traces.
+    required: false
+    type: boolean
 runs:
   using: composite
   steps:
@@ -26,6 +31,10 @@ runs:
       PR_OPTIONS: ${{ inputs.pr_options }}
     name: Update `make docs` procedure
     run: |
+      if ${{ inputs.trace }}; then
+        set -x
+      fi
+
       # If the branch already exists in the remote, the job of the script is to update that branch.
       # Otherwise, it should create a new branch.
       if git fetch origin "${BRANCH}"; then
@@ -49,5 +58,7 @@ runs:
       git push -v origin "refs/heads/${BRANCH}"
 
       # Create a PR if one doesn't already exist.
-      gh pr create --fill ${PR_OPTIONS} || true
+      if ! gh pr view "${BRANCH}"; then
+        gh pr create --fill ${PR_OPTIONS}
+      fi
     shell: bash

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -49,5 +49,5 @@ runs:
       git push -v origin "refs/heads/${BRANCH}"
 
       # Create a PR if one doesn't already exist.
-      gh pr create --fill ${PR OPTIONS} || true
+      gh pr create --fill ${PR_OPTIONS} || true
     shell: bash

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -1,0 +1,38 @@
+name: Update `make docs` procedure
+description: This action updates the `make docs` script and related Makefiles.
+inputs:
+  branch:
+    description: Name of remote branch to push changes to. Should be unique to avoid conflict with user-created branches.
+    default: update-make-docs
+    required: false
+  directory:
+    description: Directory within the repository that should contain the script and related Makefiles.
+    default: docs
+    required: false
+  pr_options:
+    description: Additional command line options provided to the `gh pr create` command.
+    required: false
+  token:
+    description: Used to open the PR.
+    default: ${{ github.token }}
+    required: false
+runs:
+  using: composite
+  steps:
+  - run: |
+      git fetch origin "${BRANCH}" || true
+      git checkout -b "${BRANCH}"
+      curl -s -Lo "${DIRECTORY}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
+      curl -s -Lo "${DIRECTORY}/make-docs" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
+      if git diff --exit-code; then exit 0; fi
+      git add .
+      git config --local user.email "bot@grafana.com"
+      git config --local user.name "grafanabot"
+      git commit --message "Update \`make docs\` procedure"
+      git push -v origin "refs/heads/${BRANCH}"
+      gh pr create --fill ${PR OPTIONS} || true
+    env:
+      BRANCH: ${{ inputs.branch }}
+      DIRECTORY: ${{ inputs.directory }}
+      GITHUB_TOKEN: ${{ inputs.github_token }}
+      PR_OPTIONS: ${{ inputs.pr_options }}

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -47,15 +47,15 @@ runs:
       curl -s -Lo "${DIRECTORY}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
       curl -s -Lo "${DIRECTORY}/make-docs" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
 
-      # If there are no changes, there is nothing more to do.
-      if git diff --exit-code; then exit 0; fi
-
-      # Commit the updated files as the Grafanabot GitHub user.
-      git add .
-      git config --local user.email "bot@grafana.com"
-      git config --local user.name "grafanabot"
-      git commit --message "Update \`make docs\` procedure"
-      git push -v origin "refs/heads/${BRANCH}"
+      # Add and commit files if there are changes.
+      if ! git diff --exit-code; then
+        # Commit the updated files as the Grafanabot GitHub user.
+        git add .
+        git config --local user.email "bot@grafana.com"
+        git config --local user.name "grafanabot"
+        git commit --message "Update \`make docs\` procedure"
+        git push -v origin "refs/heads/${BRANCH}"
+      fi
 
       # Create a PR if one doesn't already exist.
       if ! gh pr view "${BRANCH}"; then

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -19,7 +19,12 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: |
+  - env:
+      BRANCH: ${{ inputs.branch }}
+      DIRECTORY: ${{ inputs.directory }}
+      GITHUB_TOKEN: ${{ inputs.github_token }}
+      PR_OPTIONS: ${{ inputs.pr_options }}
+    run: |
       git fetch origin "${BRANCH}" || true
       git checkout -b "${BRANCH}"
       curl -s -Lo "${DIRECTORY}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
@@ -31,8 +36,4 @@ runs:
       git commit --message "Update \`make docs\` procedure"
       git push -v origin "refs/heads/${BRANCH}"
       gh pr create --fill ${PR OPTIONS} || true
-    env:
-      BRANCH: ${{ inputs.branch }}
-      DIRECTORY: ${{ inputs.directory }}
-      GITHUB_TOKEN: ${{ inputs.github_token }}
-      PR_OPTIONS: ${{ inputs.pr_options }}
+    shell: bash

--- a/update-make-docs/action.yml
+++ b/update-make-docs/action.yml
@@ -24,16 +24,30 @@ runs:
       DIRECTORY: ${{ inputs.directory }}
       GITHUB_TOKEN: ${{ inputs.github_token }}
       PR_OPTIONS: ${{ inputs.pr_options }}
+    name: Update `make docs` procedure
     run: |
-      git fetch origin "${BRANCH}" || true
-      git checkout -b "${BRANCH}"
+      # If the branch already exists in the remote, the job of the script is to update that branch.
+      # Otherwise, it should create a new branch.
+      if git fetch origin "${BRANCH}"; then
+        git checkout "${BRANCH}"
+      else
+        git checkout -b "${BRANCH}"
+      fi
+
+      # Fetch the Makefiles and script.
       curl -s -Lo "${DIRECTORY}/docs.mk" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/docs.mk
       curl -s -Lo "${DIRECTORY}/make-docs" https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs
+
+      # If there are no changes, there is nothing more to do.
       if git diff --exit-code; then exit 0; fi
+
+      # Commit the updated files as the Grafanabot GitHub user.
       git add .
       git config --local user.email "bot@grafana.com"
       git config --local user.name "grafanabot"
       git commit --message "Update \`make docs\` procedure"
       git push -v origin "refs/heads/${BRANCH}"
+
+      # Create a PR if one doesn't already exist.
       gh pr create --fill ${PR OPTIONS} || true
     shell: bash


### PR DESCRIPTION
- Add action for updating the `make docs` procedure
- Add shell
- Add name and comments explaining behavior and support existing branches
- Fix PR_OPTIONS environment variable
- Add command traces
- Ensure PR is created if it can be
- Correctly set GH_TOKEN
- Refactor script to clarify logic
- Avoid use of `--fill` that doesn't play nice with partial fetches
- Fix open PR checkout
