### PR TITLE
Add k6-docs to list of project repositories

### DIFF
--- a/docs/sources/about-grafana-docs/index.md
+++ b/docs/sources/about-grafana-docs/index.md
@@ -20,6 +20,7 @@ These are the other Grafana OSS project repositories:
 - Loki: https://github.com/grafana/loki
 - Tempo: https://github.com/grafana/tempo
 - Mimir: https://github.com/grafana/mimir
+- k6: https://github.com/grafana/k6-docs
 
 Every repository contains a `docs/sources` directory, which is where we store our documentation.
 


### PR DESCRIPTION
Add k6-docs to the list on "Introduction to documentation", now that we have migrated the docs to Grafana. :)