### PR TITLE
Add Enterprise product acronyms

### DIFF
--- a/vale/Grafana/Acronyms.yml
+++ b/vale/Grafana/Acronyms.yml
@@ -13,6 +13,9 @@ exceptions:
   - CLI
   - CPU
   - HTTP
+  - GEL
+  - GEM
+  - GET
   - JSON
   - SDK
   - SQL


### PR DESCRIPTION
GEL stands for Grafana Enterprise Logs
GEM stands for Grafana Enterprise Metrics
GET stands for Grafana Enterprise Traces