### PR TITLE
Test problem relrf shared file

### DIFF
--- a/docs/sources/review/run-a-local-webserver/index.md
+++ b/docs/sources/review/run-a-local-webserver/index.md
@@ -77,7 +77,7 @@ When you save a file with an active local build, the page is rechecked. If the e
 
 ### Example: Page not found
 
-{{< docs/shared source="writers-toolkit" lookup="hugo-error-example-bad-link.md" version="" >}}
+{{< docs/shared source="writers-toolkit" lookup="hugo-error-example-bad-link.md" >}}
 
 For more information about linking, refer to [Links](https://grafana.com/docs/writers-toolkit/write/links/).
 

--- a/docs/sources/shared/hugo-error-example-bad-link.md
+++ b/docs/sources/shared/hugo-error-example-bad-link.md
@@ -1,9 +1,6 @@
 ---
-headless: true
+title: Hugo error example for relref
 description: Shared file for example Hugo error output.
-labels:
-  products:
-    - oss
 ---
 
 [//]: # "This file documents an example Hugo error output for relref and links."

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -398,7 +398,9 @@ Emitted Hugo errors look like this:
 
 <!-- The output example is also used in review/run-a-local-webserver. -->
 
-{{< docs/shared source="writers-toolkit" lookup="hugo-error-example-bad-link.md" version="" >}}
+{{< docs/shared source="writers-toolkit" lookup="hugo-error-example-bad-link.md" >}}
+
+{{< docs/shared source="writers-toolkit" lookup="make-help.md" >}}
 
 For additional information about Hugo error output, refer to [Test documentation changes](https://grafana.com/docs/writers-toolkit/review/run-a-local-webserver/).
 


### PR DESCRIPTION
@jdbaldry FYI - 

Shared content doesn't seem to work on the shortcodes page. The relref example file  is used in two files: write/shortcode and review/run-a-local-webserver. The included content appears on the webserver page but not on the shortcode page.

Here's what I tried for troubleshooting: 
* Removed the version="" from the include line - no change
* Changed the front matter of the include file docs/sources/shared/hugo-error-example-bad-link.md to match make-help.md `{{< docs/shared source="writers-toolkit" lookup="make-help.md" >}}`. Tested via make docs, include file didn't show up.
* Copied the make-help.md include from review/doc-validator/_index page (where the include appeared on the site preview) into the shortcode page (where none of the includes appeared on the rendered page)
* Shared file for make-help.md was included whether or not the file name was index.md or _index.md.  