### PR TITLE
Simplify verb in heading

### DIFF
--- a/docs/sources/write/style-guide/style-conventions/index.md
+++ b/docs/sources/write/style-guide/style-conventions/index.md
@@ -142,7 +142,7 @@ To create a definition list, add the term on a new line then add a new line with
 
 For additional information, refer to the [Definition Lists](https://www.markdownguide.org/extended-syntax/#definition-lists) from the Markdown Guide.
 
-### Sorting lists
+### Sort lists
 
 Sort lists and table rows alphabetically unless the order is important to understanding the information in the list or table.
 


### PR DESCRIPTION
This PR changes the gerund used in the heading `Sorting lists` to a simple verb `Sort lists`.