### PR TITLE
Fix aliases documentation and incorporate more feedback from 'Brunch and learn' session on the topic

### DIFF
--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -104,15 +104,16 @@ For an alias in the page `/docs/grafana/latest/alerting/manage-notifications/`:
 
   In this example, this is the page `/docs/grafana/latest/`.
 
-The following table demonstrates the redirect URL, **REDIRECT**, created when using the relative alias, **RELATIVE ALIAS**, in the source file for **DESTINATION**:
+The following table demonstrates how to redirect **FROM PAGE**, to **TO PAGE**.
+**RELATIVE ALIAS** is added to the front matter of **TO PAGE**.
 
-| DESTINATION                                           | RELATIVE ALIAS                           | REDIRECT                                                             |
-| ----------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------- |
-| `/docs/grafana/latest/alerting/manage-notifications/` | `./`                                     | `/docs/grafana/latest/alerting/`                                     |
-| `/docs/grafana/latest/alerting/manage-notifications/` | `./silences/`                            | `/docs/grafana/latest/alerting/silences/`                            |
-| `/docs/grafana/latest/alerting/manage-notifications/` | `./manage-notifications/create-silence/` | `/docs/grafana/latest/alerting/manage-notifications/create-silence/` |
-| `/docs/grafana/latest/alerting/manage-notifications/` | `../`                                    | `/docs/grafana/latest/`                                              |
-| `/docs/grafana/latest/alerting/manage-notifications/` | `../old-alerting/`                       | `/docs/grafana/latest/old-alerting/`                                 |
+| FROM PAGE                                                            | TO PAGE                                               | RELATIVE ALIAS                           |
+| -------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------- |
+| `/docs/grafana/latest/alerting/`                                     | `/docs/grafana/latest/alerting/manage-notifications/` | `./`                                     |
+| `/docs/grafana/latest/alerting/silences/`                            | `/docs/grafana/latest/alerting/manage-notifications/` | `./silences/`                            |
+| `/docs/grafana/latest/alerting/manage-notifications/create-silence/` | `/docs/grafana/latest/alerting/manage-notifications/` | `./manage-notifications/create-silence/` |
+| `/docs/grafana/latest/`                                              | `/docs/grafana/latest/alerting/manage-notifications/` | `../`                                    |
+| `/docs/grafana/latest/old-alerting/`                                 | `/docs/grafana/latest/alerting/manage-notifications/` | `../old-alerting/`                       |
 
 #### Other projects
 

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -98,11 +98,11 @@ For an alias in the page `/docs/grafana/latest/alerting/manage-notifications/`:
 
 - The current directory element (`.`) refers to the directory containing the current page.
 
-  In this example, this is the page `/docs/grafana/latest/alerting/manage-notifications/`.
+  In this example, this is the page `/docs/grafana/latest/alerting/`.
 
 - The parent directory element (`..`) refers to the parent directory of the current directory element.
 
-  In this example, this is the page `/docs/grafana/latest/alerting/`.
+  In this example, this is the page `/docs/grafana/latest/`.
 
 The following table demonstrates the redirect URL, **REDIRECT**, created when using the relative alias, **RELATIVE ALIAS**, in the source file for **DESTINATION**:
 

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -104,8 +104,11 @@ For an alias in the page `/docs/grafana/latest/alerting/manage-notifications/`:
 
   In this example, this is the page `/docs/grafana/latest/`.
 
-The following table demonstrates how to redirect **FROM PAGE**, to **TO PAGE**.
-**RELATIVE ALIAS** is added to the front matter of **TO PAGE**.
+In the following table:
+
+- **FROM PAGE**: is the page that requires a redirect, for example because the page has been moved or no longer exists.
+- **TO PAGE**: is the page where readers are redirected to, for example the renamed page or where the content has been moved.
+- **RELATIVE ALIAS**: is the alias that must be added to the front matter of the file for **TO PAGE** to create the proper redirect.
 
 | FROM PAGE                                                            | TO PAGE                                               | RELATIVE ALIAS                           |
 | -------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------- |

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -96,7 +96,7 @@ To determine the relative alias, you must first understand the meaning of the cu
 
 For an alias in the page `/docs/grafana/latest/alerting/manage-notifications/`:
 
-- The current directory element (`.`) refers to the directory containing the current page.
+- The current directory element (`.`) refers to the directory containing the current page, _not_ the directory of the current page.
 
   In this example, this is the page `/docs/grafana/latest/alerting/`.
 


### PR DESCRIPTION
- Fix bad example
- Emphasize that the current directory is the directory containing the page, not the directory of the page
- Use more easily understood terminology in table demonstration
