### PR TITLE
Add a couple of examples for convenience

### DIFF
--- a/docs/sources/write/links/index.md
+++ b/docs/sources/write/links/index.md
@@ -105,7 +105,7 @@ To convert a heading to an anchor, make the following changes:
 1. Convert to lower case.
 1. Remove any period characters (`.`).
 1. Replace any character that's not a lower cased letter, a number, or an underscore (`_`) with dashes (`-`).
-   Some examples include `.`, `/`, or `\`.
+   Some examples are `(`, `)`, `/`, and `\`.
 1. Trim any preceding or proceeding dashes (`-`).
 1. Prefix with a `#`.
 


### PR DESCRIPTION
When figuring out how to markup a heading when it is in a URL, it is helpful to include some examples so that it catches my eye. Perhaps this is also useful for others too.