### PR TITLE
Clarification about ref links in admonitions

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -45,7 +45,7 @@ Your reader can feel free to skip them if they wish because they do not contribu
 
 {{% admonition type="warning" %}}
 Reference style links such as `[link text][label]` or `[link text][]` don't work in the inner text of shortcodes if you use reference links defined at the topic level.
-You must define the reference links within the admonition shortcode.
+To use reference links within an admonition, you must use standard inline markdown links or define the reference links within the admonition shortcode.
 
 For more information, refer to [Markdown Reference Links in Shortcodes](https://discourse.gohugo.io/t/markdown-reference-links-in-shortcodes/5770/3).
 {{% /admonition %}}

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -44,7 +44,9 @@ Tips are intended to be helpful, additional information. You can think of some t
 Your reader can feel free to skip them if they wish because they do not contribute to core understanding.
 
 {{% admonition type="warning" %}}
-Reference style links such as `[link text][label]` or `[link text][]` do not work in the inner text of shortcodes.
+Reference style links such as `[link text][label]` or `[link text][]` don't work in the inner text of shortcodes if you use reference links defined at the topic level.
+You must define the reference links within the admonition shortcode.
+
 For more information, refer to [Markdown Reference Links in Shortcodes](https://discourse.gohugo.io/t/markdown-reference-links-in-shortcodes/5770/3).
 {{% /admonition %}}
 


### PR DESCRIPTION
The note about reference links not working within admonition shortcodes isn't accurate. 

Reference links don't work in admonitions if you are using references defined at the topic level (outside the admonition)

Reference links do work if you define the links within the admonition.

Example. The following admonition uses inline link definitions.
```
{{% admonition type="note" %}}
The Grafana shortcode templates are defined in the `layouts/shortcodes` folder of the website repository which is only accessible to Grafana Labs employees.
To request custom shortcodes, [create an issue](https://github.com/grafana/writers-toolkit/issues).
{{% /admonition %}}
```

This admonition will also render properly if you define reference links within the admonition.

```
{{% admonition type="note" %}}
The Grafana shortcode templates are defined in the `layouts/shortcodes` folder of the website repository which is only accessible to Grafana Labs employees.
To request custom shortcodes, [create an issue][create].

[create]: https://github.com/grafana/writers-toolkit/issues
{{% /admonition %}}
```
