### PR TITLE
Add cascade and param info to Front Matter and Shortcodes topics

### DIFF
--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -171,7 +171,7 @@ For content reused in Grafana Cloud, prefer the open source documentation as the
 
 You can use `cascade` to define variables. For example:
 
-```
+```yaml
 cascade:
   PRODUCT_VERSION: 10.1
   PRODUCT_NAME: Grafana

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -177,7 +177,11 @@ cascade:
   PRODUCT_NAME: Grafana
 ```
 
+<!-- vale Grafana.Spelling = NO -->
+
 Use the [param](https://grafana.com/docs/writers-toolkit/write/shortcodes#param) shortcode in the topic body text wherever you need to insert the variable.
+
+<!-- vale Grafana.Spelling = YES -->
 
 ### Date
 

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -165,6 +165,20 @@ For example, `https://grafana.com/docs/writers-toolkit/`.
 
 For content reused in Grafana Cloud, prefer the open source documentation as the canonical page.
 
+### Cascade
+
+`cascade` is a map of front matter keys. The values are passed down from the parent to the page descendants.
+
+You can use `cascade` to define variables. For example:
+
+```
+cascade:
+  PRODUCT_VERSION: 10.1
+  PRODUCT_NAME: Grafana
+```
+
+Use the [param](https://grafana.com/docs/writers-toolkit/write/shortcodes#param) shortcode in the topic body text wherever you need to insert the variable.
+
 ### Date
 
 `date` describes the initial publish date of the page.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -406,7 +406,7 @@ cascade:
 The `param` shortcode in the topic body text:
 
 ```markdown
-Welcome to Grafana {{</* param PRODUCT_VERSION */>}}! Read on to learn about changes to dashboards and visualizations, data sources, security and authentication, and more.
+Welcome to Grafana {{</* param PRODUCT_VERSION */>}}. Read on to learn about changes to dashboards and visualizations, data sources, security and authentication, and more.
 ```
 
 The `param` shortcode in a topic heading:

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -414,9 +414,6 @@ The `param` shortcode in a topic heading:
 ```markdown
 ## What's new in Grafana {{%/* param PRODUCT_VERSION */%}}.
 ```
-<!-- vale Grafana.Spelling = YES -->
-
-<!-- vale Grafana.Spelling = NO -->
 
 ## Relref
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -398,7 +398,7 @@ To add a new variable definition:
 
 The front matter definition for a product version:
 
-```markdown
+```yaml
 cascade:
    PRODUCT_VERSION: 10.2
 ```

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -381,12 +381,9 @@ In this example, the image's display size is changed to have a maximum width of 
 {{</* figure src="/static/img/docs/grafana-cloud/k8sPods.png" width="1275" height="738" max-width="500px" class="w-100p" link-class="w-fit mx-auto d-flex flex-direction-column" caption="Pod view in Grafana Kubernetes Monitoring" caption-align="center" */>}}
 ```
 
-
 <!-- vale Grafana.Spelling = NO -->
 
 ## Param
-
-<!-- vale Grafana.Spelling = YES -->
 
 The `param` shortcode provides build-time variable substitution.
 
@@ -417,6 +414,7 @@ The `param` shortcode in a topic heading:
 ```markdown
 ## What's new in Grafana {{%/* param PRODUCT_VERSION */%}}.
 ```
+<!-- vale Grafana.Spelling = YES -->
 
 <!-- vale Grafana.Spelling = NO -->
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -381,6 +381,43 @@ In this example, the image's display size is changed to have a maximum width of 
 {{</* figure src="/static/img/docs/grafana-cloud/k8sPods.png" width="1275" height="738" max-width="500px" class="w-100p" link-class="w-fit mx-auto d-flex flex-direction-column" caption="Pod view in Grafana Kubernetes Monitoring" caption-align="center" */>}}
 ```
 
+
+<!-- vale Grafana.Spelling = NO -->
+
+## Param
+
+<!-- vale Grafana.Spelling = YES -->
+
+The `param` shortcode provides build-time variable substitution.
+
+To add a new variable definition:
+
+1. Define a [`cascade` variable](https://grafana.com/docs/writers-toolkit/write/front-matter/#cascade) in the parent topic.
+1. Insert the `param` variable where it's required in the parent and child topics.
+
+> **Note:** If you use the `param` shortcode in headings, you must use `%` in place of `<` and `>`. For example: `{{%/* param VARIABLE */%}}`.
+
+### Example
+
+The front matter definition for a product version:
+
+```markdown
+cascade:
+   PRODUCT_VERSION: 10.2
+```
+
+The `param` shortcode in the topic body text:
+
+```markdown
+Welcome to Grafana {{</* param PRODUCT_VERSION */>}}! Read on to learn about changes to dashboards and visualizations, data sources, security and authentication, and more.
+```
+
+The `param` shortcode in a topic heading:
+
+```markdown
+## What's new in Grafana {{%/* param PRODUCT_VERSION */%}}.
+```
+
 <!-- vale Grafana.Spelling = NO -->
 
 ## Relref

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -400,7 +400,7 @@ The front matter definition for a product version:
 
 ```yaml
 cascade:
-   PRODUCT_VERSION: 10.2
+  PRODUCT_VERSION: 10.2
 ```
 
 The `param` shortcode in the topic body text:


### PR DESCRIPTION
This PR adds `cascade` and `param` info to Front Matter and shortcodes topics in the Writer's Toolkit