### PR TITLE
Document front matter for tutorials

### DIFF
--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -281,3 +281,74 @@ By default, topics are displayed in alphabetical order by `title`.
 Use `weight` to specify a different topic order within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic earlier in the guide or section of the guide. Pages with the same weight are displayed in alphabetical order.
 
 Use increments of `100` for content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
+
+## Tutorials
+
+There is additional front matter that you only need for tutorials.
+Tutorials should also include all the regular front matter.
+
+### Associated technologies
+
+The `associated_technologies` front matter is a sequence of strings that refer to taxonomies in the website data directory.
+If you are a Grafana Labs employee, you can add view and add authors to the [website data directory](https://github.com/grafana/website/tree/master/data/taxonomies/associated_technologies).
+
+The `associated_technologies` value is the filename without the file extension.
+For example, to refer to author defined in the `mimir.yaml` file, use `mimir`.
+
+If you don't set the `associated_technologies` front matter, `grafana` is the good default.
+
+The following YAML example demonstrates setting a single associated technology of `mimir`.
+You must incorporate it with the rest of your front matter.
+
+```yaml
+associated_technologies:
+  - mimir
+```
+
+### Authors
+
+The `authors` front matter is a sequence of strings that refer to author files defined in the website data directory.
+If you are a Grafana Labs employee, you can add view and add authors to the [website data directory](https://github.com/grafana/website/tree/master/data/authors).
+
+The `authors` value is the filename without the file extension.
+For example, to refer to author defined in the `grafana_labs.yaml` file, use `grafana_labs`.
+
+If no appropriate author file exists, `grafana_labs` is a good default.
+
+The following YAML example demonstrates setting a single author of `grafana_labs`.
+You must incorporate it with the rest of your front matter.
+
+```yaml
+authors:
+  - grafana_labs
+```
+
+### Summary
+
+The `summary` front matter defines a short summary used on the tutorial's card on https://grafana.com/tutorials/.
+
+The following YAML example demonstrates setting a the summary front matter.
+You must incorporate it with the rest of your front matter.
+
+```yaml
+summary: Use Telegraf to stream live metrics to Grafana.
+```
+
+### Tags
+
+The `tags` front matter is a sequence of strings displayed as tags underneath the author section on the tutorials page.
+
+Typically, at least one of the tags is an expertise level.
+The expertise levels are:
+
+- Beginner
+- Intermediate
+- Advanced
+
+The following YAML example demonstrates setting a single tag of the expertise level `Beginner`.
+You must incorporate it with the rest of your front matter.
+
+```yaml
+tags:
+  - Beginner
+```

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -202,7 +202,8 @@ Use `description` to provide the short description of the topic to search engine
 
 The number of characters vary by media, so make the description concise.
 Provide enough information to guide users to the content by describing what content the link leads to.
-Often, this doesn’t need to be original text, you can scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
+Often, this doesn’t need to be original text.
+You can scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
 If the description is too long, it's harmlessly truncated on social media.
 
 ### Draft

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -202,9 +202,8 @@ Use `description` to provide the short description of the topic to search engine
 
 The number of characters vary by media, so make the description concise.
 Provide enough information to guide users to the content by describing what content the link leads to.
-Often, this doesn’t need to be original text, you can often scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
-If it's too long, it is harmlessly truncated on social media.
-Use double quotes (`"`) to surround the title. Do not use smart quotes.
+Often, this doesn’t need to be original text, you can scan the first few paragraphs to pluck the appropriate terms or phrases into the description.
+If the description is too long, it's harmlessly truncated on social media.
 
 ### Draft
 
@@ -282,24 +281,3 @@ By default, topics are displayed in alphabetical order by `title`.
 Use `weight` to specify a different topic order within the left-hand sidebar on https://grafana.com. Smaller numbers place the topic earlier in the guide or section of the guide. Pages with the same weight are displayed in alphabetical order.
 
 Use increments of `100` for content files. Doing so makes it easier for you to re-order existing topics when you add new topics. Weights are per directory.
-
-## Example with different page and menu titles
-
-```
----
-title: About Grafana Mimir architecture
-menuTitle: Architecture
----
-```
-
-## Description example
-
-On Twitter:
-
-![Twitter description](twitter.png)
-
-For example:
-
-- Add a panel using these steps.
-- Understand the configuration options provided by…
-- Learn more about hash rings and their usage

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -327,7 +327,7 @@ authors:
 
 The `summary` front matter defines a short summary used on the tutorial's card on https://grafana.com/tutorials/.
 
-The following YAML example demonstrates setting a the summary front matter.
+The following YAML example demonstrates summary front matter.
 You must incorporate it with the rest of your front matter.
 
 ```yaml
@@ -336,7 +336,7 @@ summary: Use Telegraf to stream live metrics to Grafana.
 
 ### Tags
 
-The `tags` front matter is a sequence of strings displayed as tags underneath the author section on the tutorials page.
+The `tags` front matter is a sequence of strings displayed as tags under the author section on the tutorials page.
 
 Typically, at least one of the tags is an expertise level.
 The expertise levels are:

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -295,7 +295,7 @@ If you are a Grafana Labs employee, you can add view the associated technologies
 The `associated_technologies` value is the filename without the file extension.
 For example, to refer to author defined in the `mimir.yaml` file, use `mimir`.
 
-If you don't set the `associated_technologies` front matter, `grafana` is the good default.
+If you don't set the `associated_technologies` front matter, `grafana` is the default.
 
 The following YAML example demonstrates setting a single associated technology of `mimir`.
 You must incorporate it with the rest of your front matter.

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -290,7 +290,7 @@ Tutorials should also include all the regular front matter.
 ### Associated technologies
 
 The `associated_technologies` front matter is a sequence of strings that refer to taxonomies in the website data directory.
-If you are a Grafana Labs employee, you can add view and add authors to the [website data directory](https://github.com/grafana/website/tree/master/data/taxonomies/associated_technologies).
+If you are a Grafana Labs employee, you can add view the associated technologies in the [website data directory](https://github.com/grafana/website/tree/master/data/taxonomies/associated_technologies).
 
 The `associated_technologies` value is the filename without the file extension.
 For example, to refer to author defined in the `mimir.yaml` file, use `mimir`.

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -291,7 +291,7 @@ Tutorials should also include all the regular front matter.
 ### Associated technologies
 
 The `associated_technologies` front matter is a sequence of strings that refer to taxonomies in the website data directory.
-If you are a Grafana Labs employee, you can add view the associated technologies in the [website data directory](https://github.com/grafana/website/tree/master/data/taxonomies/associated_technologies).
+If you are a Grafana Labs employee, you can view the associated technologies in the [website data directory](https://github.com/grafana/website/tree/master/data/taxonomies/associated_technologies).
 
 The `associated_technologies` value is the filename without the file extension.
 For example, to refer to author defined in the `mimir.yaml` file, use `mimir`.
@@ -309,7 +309,7 @@ associated_technologies:
 ### Authors
 
 The `authors` front matter is a sequence of strings that refer to author files defined in the website data directory.
-If you are a Grafana Labs employee, you can add view and add authors to the [website data directory](https://github.com/grafana/website/tree/master/data/authors).
+If you are a Grafana Labs employee, you can view and add authors to the [website data directory](https://github.com/grafana/website/tree/master/data/authors).
 
 The `authors` value is the filename without the file extension.
 For example, to refer to author defined in the `grafana_labs.yaml` file, use `grafana_labs`.

--- a/docs/sources/write/style-guide/write-for-developers/index.md
+++ b/docs/sources/write/style-guide/write-for-developers/index.md
@@ -161,7 +161,7 @@ For example:
 > The following YAML example demonstrates the configuration of a single port numbered `80` using the `TCP` protocol.
 >
 > It's part of a Kubernetes Service specification.
-> It's not a complete Service specification and your must incorporate it with the rest of a Service specification.
+> It's not a complete Service specification and you must incorporate it with the rest of a Service specification.
 >
 > ```yaml
 > ports:
@@ -179,7 +179,7 @@ The following example extends the one in the previous section:
 > The following YAML example demonstrates the configuration of a single port numbered `80` using the `TCP` protocol.
 >
 > It's part of a Kubernetes Service specification.
-> It's not a complete Service specification and your must incorporate it with the rest of a Service specification.
+> It's not a complete Service specification and you must incorporate it with the rest of a Service specification.
 >
 > To incorporate the example, you must include it as the value to the Service `spec` mapping.
 > If there is an existing `ports` value, you must choose to replace it or merge the two.


### PR DESCRIPTION
Closes https://github.com/grafana/writers-toolkit/issues/286

The deletions come from [596217b](https://github.com/grafana/writers-toolkit/pull/448/commits/596217bf8dfebf53fc68d81d8900bf033fae1380). I'm not sure why that content was where it was and I don't think it is worth incorporating with the rest of the page.