### PR TITLE
Add node exporter to word list

### DIFF
--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -76,9 +76,9 @@ Use this rather than _hamburger menu_ or _kebab menu_.
 
 ## N
 
-### Node Explorer
+### Node Exporter
 
-When referring to the Prometheus Node Explorer, capitalize both words in the term _Node Explorer_. Don't use _Node explorer_ or _node explorer_.
+When referring to the Prometheus Node Exporter, capitalize both words in the term _Node Exporter. Don't use _Node exporter or _node exporter.
 
 <!--
 ## O

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -74,7 +74,6 @@ Use this rather than _hold the pointer over_ or _point to_.
 
 Use this rather than _hamburger menu_ or _kebab menu_.
 
-
 ## N
 
 ### Node Explorer

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -78,7 +78,7 @@ Use this rather than _hamburger menu_ or _kebab menu_.
 
 ### Node Exporter
 
-When referring to the Prometheus Node Exporter, capitalize both words in the term _Node Exporter. Don't use _Node exporter or _node exporter.
+When referring to the Prometheus Node Exporter, capitalize both words in the term _Node Exporter_. Don't use _Node exporter_ or _node exporter_.
 
 <!--
 ## O

--- a/docs/sources/write/style-guide/word-list/index.md
+++ b/docs/sources/write/style-guide/word-list/index.md
@@ -74,8 +74,14 @@ Use this rather than _hold the pointer over_ or _point to_.
 
 Use this rather than _hamburger menu_ or _kebab menu_.
 
-<!--
+
 ## N
+
+### Node Explorer
+
+When referring to the Prometheus Node Explorer, capitalize both words in the term _Node Explorer_. Don't use _Node explorer_ or _node explorer_.
+
+<!--
 ## O
 ## P
 ## Q -->


### PR DESCRIPTION
Add correct capitalization of Node Exporter to word list. This decision was made in the style roundtable based on how it's referred to in the [Prometheus docs](https://prometheus.io/docs/guides/node-exporter/).