### PR TITLE
Add matcher to dictionary

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-83
+84
 Aerospike/ po:noun
 Alertmanager/S po:noun
 allowlist/S po:noun
@@ -38,6 +38,7 @@ JUnit/ po:noun
 Kinesis/ po:noun
 KPI/S po:noun
 kubelet/ po:noun
+matcher/S po:noun
 misconfiguration/S po:noun
 namespace/S po:noun
 OAuth/ po:noun

--- a/vale/dictionaries/en_US-grafana.wordlist
+++ b/vale/dictionaries/en_US-grafana.wordlist
@@ -37,6 +37,7 @@ JUnit/ po:noun
 Kinesis/ po:noun
 KPI/S po:noun
 kubelet/ po:noun
+matcher/S po:noun
 misconfiguration/S po:noun
 namespace/S po:noun
 OAuth/ po:noun


### PR DESCRIPTION
It is a Prometheus term for the labels specified in a query used to match specific series.