### PR TITLE
Add AWS Observability

### DIFF
--- a/vale/Grafana/Headings.yml
+++ b/vale/Grafana/Headings.yml
@@ -16,6 +16,7 @@ exceptions:
   - Amazon Kinesis Data Firehose
   - Ansible
   - Application Observability
+  - AWS Observability
   - AzureAD
   - Beyla
   - BoltDB


### PR DESCRIPTION
> Grafana AWS Observability for Grafana Cloud provides you with a single place to gain better visibility into the health and performance of your infrastructure and large scale applications.
> AWS Observability is available immediately with your Grafana Cloud account.

https://grafana.com/docs/grafana-cloud/monitor-infrastructure/aws/