### PR TITLE
Remove flamegraph in favor of flame graph

### DIFF
--- a/vale/dictionaries/en_US-grafana.wordlist
+++ b/vale/dictionaries/en_US-grafana.wordlist
@@ -30,7 +30,6 @@ ESLint/ po:noun
 etcd/ po:noun
 Fargate/ po:noun
 Firehose/ po:noun
-flamegraph/S po:noun
 Goldmark/ po:noun
 goroutine/S po:noun
 Grafana/ po:adjective


### PR DESCRIPTION
Remove flamegraph. The content team chimed in and decided we should use flame graph as two words. I've reverted the change I made earlier and have also reviewed all of the content in the Cloud Profiles content to make flame graph two words in the documentation. I'll update the Pyroscope OSS content next. 

Part of https://github.com/grafana/pyroscope-squad/issues/123