### PR TITLE
Revert "Add profile verb form and affixes"

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-133
+134
 ACL/S po:noun
 Aerospike/ po:noun
 Alertmanager/MS po:noun
@@ -77,6 +77,7 @@ performant/ po:adjective
 Phlare/M po:noun
 Podman/M po:noun
 preconfigure/D po:verb
+profile/DGRS po:verb
 Promtail/M po:noun
 provision/dD po:verb
 proxy/DG po:verb

--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-134
+133
 ACL/S po:noun
 Aerospike/ po:noun
 Alertmanager/MS po:noun
@@ -77,8 +77,6 @@ performant/ po:adjective
 Phlare/M po:noun
 Podman/M po:noun
 preconfigure/D po:verb
-profile/DGRS po:verb
-profiler/DGRS po:noun
 Promtail/M po:noun
 provision/dD po:verb
 proxy/DG po:verb

--- a/vale/dictionaries/en_US-grafana.wordlist
+++ b/vale/dictionaries/en_US-grafana.wordlist
@@ -76,6 +76,7 @@ performant/ po:adjective
 Phlare/M po:noun
 Podman/M po:noun
 preconfigure/D po:verb
+profile/DGRS po:verb
 Promtail/M po:noun
 provision/dD po:verb
 proxy/DG po:verb

--- a/vale/dictionaries/en_US-grafana.wordlist
+++ b/vale/dictionaries/en_US-grafana.wordlist
@@ -76,8 +76,6 @@ performant/ po:adjective
 Phlare/M po:noun
 Podman/M po:noun
 preconfigure/D po:verb
-profile/DGRS po:verb
-profiler/DGRS po:noun
 Promtail/M po:noun
 provision/dD po:verb
 proxy/DG po:verb


### PR DESCRIPTION
Reverts grafana/writers-toolkit#592

Sorry @knylander-grafana, I didn't explain properly in my previous PR. The dictionary uses stem words and affix rules to build the dictionary. In my PR (and now this one), the stem is `profile` and the affix rules are `DGRS`. Each of those affix rules are defined in https://github.com/grafana/writers-toolkit/blob/main/vale/dictionaries/en_US-grafana.aff and they have different behavior and are somewhat mnemonic.

- `D` is the `ed` suffix
- `G` is the `ing` suffix
- `R` is the `er` suffix
- `S` is the plural suffix

Each rule knows how to correctly remove from the stem if needed to apply the suffix.

This lets me add a single stem word `profile` and have the dictionary understand all of:
- profiled
- profiling
- profiler
- profiles