### PR TITLE
[DOC] Update release notes for second person

### DIFF
--- a/docs/sources/contribute/release-notes/index.md
+++ b/docs/sources/contribute/release-notes/index.md
@@ -366,7 +366,8 @@ Follow these guidelines to ensure that your What's new or release notes content 
 
   Grafana's style normally prefers second person ("you") and avoids first person ("I"/"we").
   Release notes, like blog posts, use a more conversational tone and often use first person plural: "We’ve made multi-tenant queries available."
-  
-  If you receive an error messages from Vale linter, you can use [Skip rules](https://grafana.com/docs/writers-toolkit/review/lint-prose/#skip-rules) to ignore checks for the `Grafana.GoogleWe` rule. You can use this check at the beginning of your file after the front matter: 
+
+  If you receive an error messages from Vale linter, you can use [Skip rules](https://grafana.com/docs/writers-toolkit/review/lint-prose/#skip-rules) to ignore checks for the `Grafana.GoogleWe` rule. You can use this check at the beginning of your file after the front matter:
   `<!-- vale Grafana.GoogleWe = NO -->`
+
 <!-- vale Grafana.GoogleWe = YES -->

--- a/docs/sources/contribute/release-notes/index.md
+++ b/docs/sources/contribute/release-notes/index.md
@@ -360,7 +360,9 @@ Follow these guidelines to ensure that your What's new or release notes content 
 
 - **For changes or updates to features, provide brief descriptions.**
 
-- **Release notes and What's new are written in more of a blog-like style.**
+<!-- vale Grafana.GoogleWe = NO -->
+- **You can use first person plural, such as "we".**
 
   Grafana's style normally prefers second person ("you") and avoids first person ("I"/"we").
-  Release notes, like blog posts, are written in a more conversational tone and often use first person plural: "We’ve made multi-tenant queries available..."
+  Release notes, like blog posts, use a more conversational tone and often use first person plural: "We’ve made multi-tenant queries available."
+<!-- vale Grafana.GoogleWe = YES -->

--- a/docs/sources/contribute/release-notes/index.md
+++ b/docs/sources/contribute/release-notes/index.md
@@ -24,6 +24,11 @@ This topic explains the decisions and actions associated with collecting, writin
 This topic is only relevant for internal Grafana Labs contributors.
 {{< /admonition >}}
 
+The information on this page can be used for Grafana products that use the What's new or CMS to publish notes about new and updated features.
+However, not every product uses the What's new process for their release notes.
+For example, the release notes for Grafana Tempo are created within the Tempo repository.
+The Grafana Cloud Traces updates are published using the What's new.
+
 ## What's new documentation development process
 
 What’s new content is published to the website through the website Content Management System (CMS).
@@ -354,3 +359,8 @@ Follow these guidelines to ensure that your What's new or release notes content 
   Now, the state doesn't update."
 
 - **For changes or updates to features, provide brief descriptions.**
+
+- **Release notes and What's new are written in more of a blog-like style.**
+
+  Grafana's style normally prefers second person ("you") and avoids first person ("I"/"we").
+  Release notes, like blog posts, are written in a more conversational tone and often use first person plural: "We’ve made multi-tenant queries available..."

--- a/docs/sources/contribute/release-notes/index.md
+++ b/docs/sources/contribute/release-notes/index.md
@@ -361,8 +361,12 @@ Follow these guidelines to ensure that your What's new or release notes content 
 - **For changes or updates to features, provide brief descriptions.**
 
 <!-- vale Grafana.GoogleWe = NO -->
+
 - **You can use first person plural, such as "we".**
 
   Grafana's style normally prefers second person ("you") and avoids first person ("I"/"we").
   Release notes, like blog posts, use a more conversational tone and often use first person plural: "We’ve made multi-tenant queries available."
+  
+  If you receive an error messages from Vale linter, you can use [Skip rules](https://grafana.com/docs/writers-toolkit/review/lint-prose/#skip-rules) to ignore checks for the `Grafana.GoogleWe` rule. You can use this check at the beginning of your file after the front matter: 
+  `<!-- vale Grafana.GoogleWe = NO -->`
 <!-- vale Grafana.GoogleWe = YES -->


### PR DESCRIPTION
Clarified the release notes/what's new to address two things: 
* The What's new process isn't used by all products 
* It's okay to use "we" in the release notes and What's new since they are more conversational tone like blog posts