### PR TITLE
Add example of console output seen when there are old build processes running

### DIFF
--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -205,7 +205,15 @@ If you experience confusing behavior with the `make docs` procedure, report the 
 
 To stop the `make docs` command, press Commmand/Ctrl + C.
 
-If this doesn't work, do one of the following:
+Sometimes an old build process can be running in another terminal.
+If this is the case, when you run `make docs`, you see output similar to the following:
+
+```console
+docker: Error response from daemon: driver failed programming external connectivity on endpoint eloquent_nightingale (eb2c4546727b41bbc44354ac616a14404c57f30c312f6869b147c578ac5de6bf): Bind for 0.0.0.0:3002 failed: port is already allocated.
+make: *** [docs] Error 125
+```
+
+To remove an old build process, do one of the following:
 
 - Open Docker Desktop, go to **Containers**, and stop all running containers or just the one for your local build.
 - To remove all running containers, run `docker rm -f $(docker ps -q)`.


### PR DESCRIPTION

Encountered by @derek-cadzow