### PR TITLE
Docs: add ordinal number guidance

### DIFF
--- a/docs/sources/write/style-guide/style-conventions/index.md
+++ b/docs/sources/write/style-guide/style-conventions/index.md
@@ -173,6 +173,12 @@ For more information about Grafana Labs products, refer to [Grafana documentatio
 
 For more comprehensive guidance, refer to [Write useful link text](https://grafana.com/docs/writers-toolkit/write/links/useful-link-text/)
 
+## Numbers
+
+For direction on how to style numbers, follow the [Google style guide](https://developers.google.com/style/numbers) except in the case of ordinals.
+
+For ordinals, write out first through ninth. For 10th on, use numerals.
+
 ## Admonitions
 
 To focus a user's attention, Grafana Labs documentation includes notes, cautions, and warnings.

--- a/docs/sources/write/style-guide/style-conventions/index.md
+++ b/docs/sources/write/style-guide/style-conventions/index.md
@@ -175,7 +175,7 @@ For more comprehensive guidance, refer to [Write useful link text](https://grafa
 
 ## Numbers
 
-For direction on how to style numbers, follow the [Google style guide](https://developers.google.com/style/numbers) except in the case of ordinals.
+For direction on how to style numbers, follow the [Google style guide](https://developers.google.com/style/numbers) except in the case of _ordinals_. An ordinal number is a number that indicates the position or order of something in relation to other numbers, like first, second, third, and so on.
 
 For ordinals, write out first through ninth. For 10th on, use numerals.
 

--- a/vale/Grafana/GoogleOrdinal.yml
+++ b/vale/Grafana/GoogleOrdinal.yml
@@ -1,7 +1,0 @@
-"extends": "existence"
-"level": "error"
-"link": "https://developers.google.com/style/numbers"
-"message": "Spell out all ordinal numbers ('%s') in text."
-"nonword": true
-"tokens":
-  - "\\d+(?:st|nd|rd|th)"

--- a/vale/Grafana/Ordinal.yml
+++ b/vale/Grafana/Ordinal.yml
@@ -1,0 +1,15 @@
+extends: existence
+level: error
+link: https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#numbers
+message: For ordinals, write out first through ninth. For 10th on, use numerals.
+nonword: true
+tokens:
+  - 1st
+  - 2nd
+  - 3rd
+  - 4th
+  - 5th
+  - 6th
+  - 7th
+  - 8th
+  - 9th

--- a/vale/google.jsonnet
+++ b/vale/google.jsonnet
@@ -20,7 +20,8 @@ std.prune({
   'Grafana/GoogleLatin.yml': null,
   'Grafana/GoogleLyHyphens.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/LyHyphens.yml')),
   'Grafana/GoogleOptionalPlurals.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/OptionalPlurals.yml')),
-  'Grafana/GoogleOrdinal.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/Ordinal.yml')),
+  // Replaced by Grafana/Ordinal.yml.
+  'Grafana/GoogleOrdinal.yml': null,
   'Grafana/GoogleOxfordComma.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/OxfordComma.yml')),
   // Replaced by Grafana/Parentheses.yml.
   'Grafana/GoogleParens.yml': null,


### PR DESCRIPTION
Adds a Numbers section to the style guide. Adds guidance to follow Google style on all number styling except in the case of ordinals.