### PR TITLE
Add rule for CHANGELOG

### DIFF
--- a/vale/Grafana/CHANGELOG.yml
+++ b/vale/Grafana/CHANGELOG.yml
@@ -8,3 +8,4 @@ action:
 swap:
   '[Cc]hangelog\.md': CHANGELOG.md
   '[Cc]hangelog': CHANGELOG
+  '[Cc]hangelogs': CHANGELOGs

--- a/vale/Grafana/CHANGELOG.yml
+++ b/vale/Grafana/CHANGELOG.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: Use '%s' instead of '%s' unless you are referring to a specific file which has that spelling.
+link: https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#changelog
+level: warning
+ignorecase: false
+action:
+  name: replace
+swap:
+  '[Cc]hangelog\.md': CHANGELOG.md
+  '[Cc]hangelog': CHANGELOG

--- a/vale/Grafana/README.yml
+++ b/vale/Grafana/README.yml
@@ -7,4 +7,5 @@ action:
   name: replace
 swap:
   '[Rr]eadme\.md': README.md
-  "[Rr]eadme": README
+  '[Rr]eadme': README
+  '[Rr]eadmes': READMEs


### PR DESCRIPTION
https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#changelog

> When naming a file or making a general reference to CHANGELOGs, spell using all caps. When referencing a specific CHANGELOG file, match the same capitalization of that file.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>