### PR TITLE
Add rule for quickstart

### DIFF
--- a/vale/Grafana/Quickstart.yml
+++ b/vale/Grafana/Quickstart.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: Use the compound adjective without a hyphen whether the noun is implied or explicit. For example, you can use _quickstart guide_ or just _quickstart_.
+link: https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#quickstart
+level: warning
+ignorecase: false
+action:
+  name: replace
+swap:
+  'quick start': quickstart

--- a/vale/fixtures/Grafana/Quickstart/.vale.ini
+++ b/vale/fixtures/Grafana/Quickstart/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../../
+MinAlertLevel = suggestion
+[*.md]
+Grafana.Quickstart = YES

--- a/vale/fixtures/Grafana/Quickstart/testinvalid.golden
+++ b/vale/fixtures/Grafana/Quickstart/testinvalid.golden
@@ -1,0 +1,1 @@
+testinvalid.md:3:3:Grafana.Quickstart:Use the compound adjective without a hyphen whether the noun is implied or explicit. For example, you can use _quickstart guide_ or just _quickstart_.

--- a/vale/fixtures/Grafana/Quickstart/testinvalid.md
+++ b/vale/fixtures/Grafana/Quickstart/testinvalid.md
@@ -1,0 +1,3 @@
+Don't use:
+
+- quick start

--- a/vale/fixtures/Grafana/Quickstart/testvalid.md
+++ b/vale/fixtures/Grafana/Quickstart/testvalid.md
@@ -1,0 +1,4 @@
+Instead use:
+
+- quickstart guide
+- quickstart


### PR DESCRIPTION
https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#changelog

> When naming a file or making a general reference to CHANGELOGs, spell using all caps. When referencing a specific CHANGELOG file, match the same capitalization of that file.

Decided in the [2024-03-21 Style roundtable meeting](https://docs.google.com/document/d/1uCjtHEy0lpZggkpgsLDjWwxV9K6h7vcsG2dy4TOS6EA/edit#heading=h.fcyxlafuji70)

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>