### PR TITLE
Fix Grafana/Ordinal reporting errors on multiple digit ordinals

### DIFF
--- a/vale/Grafana/Ordinal.yml
+++ b/vale/Grafana/Ordinal.yml
@@ -2,7 +2,6 @@ extends: existence
 level: error
 link: https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#numbers
 message: For ordinals, write out first through ninth. For 10th on, use numerals.
-nonword: true
 tokens:
   - 1st
   - 2nd

--- a/vale/fixtures/Grafana/Ordinal/.vale.ini
+++ b/vale/fixtures/Grafana/Ordinal/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../../
+MinAlertLevel = suggestion
+[*.md]
+Grafana.Ordinal = YES

--- a/vale/fixtures/Grafana/Ordinal/testinvalid.golden
+++ b/vale/fixtures/Grafana/Ordinal/testinvalid.golden
@@ -1,0 +1,9 @@
+testinvalid.md:3:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:4:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:5:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:6:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:7:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:8:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:9:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:10:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.
+testinvalid.md:11:3:Grafana.Ordinal:For ordinals, write out first through ninth. For 10th on, use numerals.

--- a/vale/fixtures/Grafana/Ordinal/testinvalid.md
+++ b/vale/fixtures/Grafana/Ordinal/testinvalid.md
@@ -1,0 +1,11 @@
+Don't use:
+
+- 1st
+- 2nd
+- 3rd
+- 4th
+- 5th
+- 6th
+- 7th
+- 8th
+- 9th

--- a/vale/fixtures/Grafana/Ordinal/testvalid.md
+++ b/vale/fixtures/Grafana/Ordinal/testvalid.md
@@ -1,0 +1,13 @@
+Instead use:
+
+- first
+- second
+- third
+- fourth
+- fifth
+- sixth
+- seventh
+- eighth
+- ninth
+- 10th
+- 75th


### PR DESCRIPTION
The nonword configuration meant that the token `5th` matches in `75th` for example.