### PR TITLE
Add boolean to dictionary.jsonnet

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-192
+193
 ACL/S po:noun
 Aerospike/ po:noun
 Agent/ po:noun
@@ -16,6 +16,7 @@ backport/DGS po:verb
 Beyla/ po:noun
 blackbox/ po:noun
 blockquote/S po:noun
+boolean/ po:noun
 BPF/ po:noun
 burndown/ po:adjective
 cAdvisor/M po:noun

--- a/vale/dictionary.jsonnet
+++ b/vale/dictionary.jsonnet
@@ -38,6 +38,7 @@ local newWord(word, affixes, po) = {
     newWord('Beyla', '', 'noun') { product: true },
     newWord('blackbox', '', 'noun'),
     newWord('blockquote', 'S', 'noun'),
+    newWord('boolean', '', 'noun'),
     newWord('BPF', '', 'noun') { acronym: true, established_acronym: true },
     newWord('burndown', '', 'adjective'),
     newWord('cAdvisor', 'M', 'noun'),


### PR DESCRIPTION
Looking at the Google style guide and in the context of technical docs, I think we should include the lowercase boolean to our dictionary: https://developers.google.com/style/word-list#boolean.