### PR TITLE
Fix false positive for Zipkin product and add OTLP acronym

### DIFF
--- a/vale/Grafana/Acronyms.yml
+++ b/vale/Grafana/Acronyms.yml
@@ -21,6 +21,7 @@
   - "JSX"
   - "LESS"
   - "OSS"
+  - "OTLP"
   - "PDF"
   - "PHP"
   - "PNG"

--- a/vale/Grafana/Archives.yml
+++ b/vale/Grafana/Archives.yml
@@ -4,7 +4,6 @@ link: https://developers.google.com/style/word-list#extract
 message: Use '%s' instead of '%s'.
 
 ignorecase: false
-nonword: true
 
 action:
   name: replace

--- a/vale/Makefile
+++ b/vale/Makefile
@@ -14,9 +14,9 @@ help:
 PODMAN := $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-all: fixtures/Grafana Grafana/Google Grafana/Readability Grafana/ProductPossessives.yml Grafana/Acronyms.yml
+all: dictionaries/en_US-grafana.dic fixtures/Grafana Grafana/Google Grafana/Readability Grafana/ProductPossessives.yml Grafana/Acronyms.yml
 
-dictionaries/en_US-grafana.%: dictionaries/wordlist
+dictionaries/en_US-grafana.%:
 	$(MAKE) -C $(@D) $(@F)
 
 .PHONY: grafana/vale

--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-194
+195
 ACL/S po:noun
 Aerospike/ po:noun
 Agent/ po:noun
@@ -104,6 +104,7 @@ OpenTelemetry/M po:noun
 OSS/ po:noun
 OTel/ po:adjective
 OTel/M po:noun
+OTLP/ po:noun
 overbill/DG po:verb
 Parca/M po:noun
 PDF/S po:noun

--- a/vale/dictionary.jsonnet
+++ b/vale/dictionary.jsonnet
@@ -126,6 +126,7 @@ local newWord(word, affixes, po) = {
     newWord('OSS', '', 'noun') { acronym: true, established_acronym: true },
     newWord('OTel', '', 'adjective'),
     newWord('OTel', 'M', 'noun'),
+    newWord('OTLP', '', 'noun') { acronym: true, established_acronym: true },
     newWord('overbill', 'DG', 'verb'),
     newWord('Parca', 'M', 'noun'),
     newWord('PDF', 'S', 'noun') { acronym: true, established_acronym: true },

--- a/vale/fixtures/Grafana/Archives/testvalid.md
+++ b/vale/fixtures/Grafana/Archives/testvalid.md
@@ -9,3 +9,5 @@ Instead use:
 
 - archive
 - compressed file
+
+Also, Zipkin the product is OK.


### PR DESCRIPTION
False positive spotted in https://github.com/grafana/tempo/pull/3626/files#diff-1e0385ba512bc0e4e0d24fc1695898b9471b5373e1f17120c1c812a60f7980e5R57-R58 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>