### PR TITLE
writers toolkit: test docs

### DIFF
--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -13,7 +13,7 @@ weight: 200
 
 {{< docs/shared source="writers-toolkit" lookup="make-help.md" >}}
 
-To run the local documentation web server, run `make docs` from the `docs/` directory. The output message should include a URL that you can follow to visualize the changes to the documentation in the browser. See the [example of a successful build](#example-succesful-build)
+To run the local documentation web server, run `make docs` from the `docs/` directory. The output message should include a URL that you can follow to view the changes to the documentation in the browser. See the [example of a successful build](#example-succesful-build).
 
 {{< admonition type="note" >}}
 Running `make docs` from the root of a repository produces the output `make: Nothing to be done for 'docs'.` instead of running the local documentation web server.

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -13,7 +13,7 @@ weight: 200
 
 {{< docs/shared source="writers-toolkit" lookup="make-help.md" >}}
 
-To run the local documentation web server, run `make docs` from the `docs/` directory.
+To run the local documentation web server, run `make docs` from the `docs/` directory. The output message will include a URL that you can follow to visualize the changes to the documentation in the browser. See the [example of a successful build](#example-succesful-build)
 
 {{< admonition type="note" >}}
 Running `make docs` from the root of a repository produces the output `make: Nothing to be done for 'docs'.` instead of running the local documentation web server.
@@ -78,6 +78,22 @@ where:
 - _`LEVEL`_ is one of `WARN` or `ERROR`
 - _`LANGUAGE`_ may be present
 - _`MESSAGE`_ is the issue
+
+### Example: Succesful build
+
+If the `make docs` command runs correctly, the console will print the following message at the bottom.
+
+```
+View documentation locally:
+  http://localhost:3002/docs/grafana/latest/
+
+Press Ctrl+C to stop the server
+```
+
+{{< admonition type="note" >}}
+To test tutorial changes the address is `http://localhost:3002/docs/grafana/latest/tutorials/`
+{{< /admonition >}}
+
 
 ### Example: Page not found
 

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -81,7 +81,7 @@ where:
 
 ### Example: Succesful build
 
-If the `make docs` command runs correctly, the console should print a message similar to the following"
+If the `make docs` command runs correctly, the console should print a message similar to the following:
 
 ```
 View documentation locally:

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -13,7 +13,7 @@ weight: 200
 
 {{< docs/shared source="writers-toolkit" lookup="make-help.md" >}}
 
-To run the local documentation web server, run `make docs` from the `docs/` directory. The output message will include a URL that you can follow to visualize the changes to the documentation in the browser. See the [example of a successful build](#example-succesful-build)
+To run the local documentation web server, run `make docs` from the `docs/` directory. The output message should include a URL that you can follow to visualize the changes to the documentation in the browser. See the [example of a successful build](#example-succesful-build)
 
 {{< admonition type="note" >}}
 Running `make docs` from the root of a repository produces the output `make: Nothing to be done for 'docs'.` instead of running the local documentation web server.
@@ -81,7 +81,7 @@ where:
 
 ### Example: Succesful build
 
-If the `make docs` command runs correctly, the console will print the following message at the bottom.
+If the `make docs` command runs correctly, the console should print the following message at the bottom.
 
 ```
 View documentation locally:

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -81,7 +81,7 @@ where:
 
 ### Example: Succesful build
 
-If the `make docs` command runs correctly, the console should print the following message at the bottom.
+If the `make docs` command runs correctly, the console should print a message similar to the following"
 
 ```
 View documentation locally:

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -79,7 +79,7 @@ where:
 - _`LANGUAGE`_ may be present
 - _`MESSAGE`_ is the issue
 
-### Example: Succesful build
+### Example: Successful build
 
 If the `make docs` command runs correctly, the console should print a message similar to the following:
 

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -94,7 +94,6 @@ Press Ctrl+C to stop the server
 To test tutorial changes the address is `http://localhost:3002/docs/grafana/latest/tutorials/`
 {{< /admonition >}}
 
-
 ### Example: Page not found
 
 {{< docs/shared source="writers-toolkit" lookup="hugo-error-example-bad-link.md" version="" >}}


### PR DESCRIPTION
This PR clarifies the output of running the `make docs` command, and also specifies what's the URL for testing tutorial changes