### PR TITLE
Review some pages

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -11,8 +11,10 @@ cascade:
   github_branch: main
   github_dir: /docs/sources
   replace_dir: docs/writers-toolkit/
-date: 2024-02-13
-description: A toolkit for writing technical documentation.
+date: 2024-05-16
+description: |
+  A toolkit for writing technical documentation for Grafana Labs.
+  Use it as the source of truth for voice and tone, grammar, style, templates, and more.
 keywords:
   - writing guide
   - style guide

--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -75,7 +75,7 @@ In that case, you can use the GitHub code navigation to try and find the new loc
 <!-- vale Grafana.Timeless = YES -->
 
 If pages don't have a **Suggest an edit** link, the documentation isn't open source.
-Only Grafana Labs employees can update to closed source documentation.
+Only Grafana Labs employees can update closed source documentation.
 
 For example, [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) is in the [website repository](https://github.com/grafana/website).
 

--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -3,8 +3,8 @@ aliases:
   - /docs/writers-toolkit/contribute/
   - /docs/writers-toolkit/contribute-documentation/
   - /docs/writers-toolkit/writing-guide/contribute-documentation/
-date: 2024-02-13
-description: This section describes the different ways of contributing to documentation.
+date: 2024-05-16
+description: Learn how you can contribute to Grafana Labs documentation.
 keywords:
   - contribute
   - request change
@@ -39,7 +39,7 @@ To report a problem:
 1. Include a link to your current page in the email.
 1. Send your email.
 
-The Doc Squad checks the email inbox regularly and responds to emails in a timely fashion.
+The Grafana Labs documentation team checks the email inbox regularly and responds to emails in a timely fashion.
 
 ## Suggest an edit
 
@@ -69,15 +69,15 @@ Because development happens in the `main` branch on GitHub which generally corre
 
 The latest version of documentation is typically published from a different _version_ branch, and the **Suggest an edit** link can result in a 404 error from GitHub.
 
-In that case, you can use the GitHub code navigation to try and find the new location or reach out to a Technical Writer for support.
+In that case, you can use the GitHub code navigation to try and find the new location or reach out to the Grafana Labs documentation team for support.
 {{< /admonition >}}
 
 <!-- vale Grafana.Timeless = YES -->
 
-For pages that don't have a **Suggest an edit** link, search the Grafana organization on GitHub for repositories that include the project name.
-For example, you can find the Loki repository, by [searching for "Loki"](https://github.com/search?q=org%3Agrafana+Loki&type=repositories).
+For pages that don't have a **Suggest an edit** link, the documentation isn't open source.
+Only Grafana Labs employees can update to closed source documentation.
 
-[Grafana Cloud](https://grafana.com/docs/grafana-cloud/) is in the [website repository](https://github.com/grafana/website).
+For example, [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) is in the [website repository](https://github.com/grafana/website).
 
 {{< admonition type="note" >}}
 The website repository is private and only accessible to Grafana Labs employees.
@@ -156,7 +156,7 @@ When you add a pull request to a repository and assign the `type/docs` label, it
 
 The Grafana Labs documentation team aims to review all PRs in a timely fashion.
 
-## Contributing across versions
+## Contribute across versions
 
 When you edit the `main` branch of a project, it affects the content in the `next` directory of the website.
 To edit a previous version, or `latest` (the most recent release), you must backport the changes into the long-lived version branches in the project repository.

--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -74,7 +74,7 @@ In that case, you can use the GitHub code navigation to try and find the new loc
 
 <!-- vale Grafana.Timeless = YES -->
 
-For pages that don't have a **Suggest an edit** link, the documentation isn't open source.
+If pages don't have a **Suggest an edit** link, the documentation isn't open source.
 Only Grafana Labs employees can update to closed source documentation.
 
 For example, [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) is in the [website repository](https://github.com/grafana/website).

--- a/docs/sources/introduction/index.md
+++ b/docs/sources/introduction/index.md
@@ -3,8 +3,8 @@ aliases:
   - /docs/writers-toolkit/about-grafana-docs/
   - /docs/writers-toolkit/introduction/
   - /docs/writers-toolkit/writing-guide/about-grafana-docs/
-date: 2024-02-13
-description: Learn about Grafana's documentation
+date: 2024-05-16
+description: Learn about how Grafana Labs manages technical documentation.
 keywords:
   - Grafana
   - documentation
@@ -20,34 +20,40 @@ Grafana Labs keeps technical documentation alongside the project code it documen
 Some open source projects and their repositories are:
 
 - Grafana: https://github.com/grafana/grafana
-- Grafana Agent: https://github.com/grafana/agent
+- Grafana Alloy: https://github.com/grafana/alloy
 - Grafana k6: https://github.com/grafana/k6-docs
 - Grafana Loki: https://github.com/grafana/loki
 - Grafana Mimir: https://github.com/grafana/mimir
+- Grafana Pyroscope: https://github.com/grafana/pyroscope
 - Grafana Tempo: https://github.com/grafana/tempo
 
 Each repository contains a `docs/sources` directory containing documentation source files.
 
 ## Topic-based authoring
 
-The technical writing team at Grafana Labs uses topic-based authoring.
+The Grafana Labs documentation team uses topic-based authoring.
 Topic-based authoring is a modular approach to content creation where content is structured around topics that can be mixed and reused in different contexts.
 
-For more information on topic types, refer to [Topic types]({{< relref "../structure/topic-types" >}}).
+For more information on topic types, refer to [Topic types](https://grafana.com/docs/writers-toolkit/structure/topic-types/).
 
 Why is topic-based authoring important?
 
-- **Writing that isn’t topic-based is difficult to reuse.** If everyone frequently copies information to multiple locations and makes small modifications, the result is rework and increases in errors, which multiplies the costs associated with maintenance and translation.
+- **Writing that isn’t topic-based is difficult to reuse.**
 
-- **Writing that isn’t topic-based is difficult for readers to understand.** Content, structure, terminology, and writing style differs and can confuse and frustrate readers.
+  If everyone copies information to multiple locations and makes small modifications, the result is rework and increases in errors, which multiplies the costs associated with maintenance and translation.
+
+- **Writing that isn’t topic-based is difficult for readers to understand.**
+
+  Content, structure, terminology, and writing style differs and can confuse and frustrate readers.
 
 - **Writing that is topic-based is more consistent and user-friendly.**
-  Users can find the information they are looking for quickly and easily.
-  It has a more consistent format and voice, clearly defining the Grafana brand.
+
+  Users can find the information they're looking for quickly and easily.
+  It has a more consistent format and voice, clearly defining the Grafana Labs brand.
 
 ## Markdown
 
-Grafana writes technical documentation using Markdown.
+Grafana Labs writes technical documentation using Markdown.
 For more information, refer to the [Markdown style guide](https://grafana.com/docs/writers-toolkit/write/markdown-guide/).
 
 ## Ways to contribute
@@ -60,4 +66,4 @@ You can contribute content in the following ways:
 
 ## Join the community
 
-For general discussions about documentation, you’re welcome to join the [#docs](https://raintank-corp.slack.com/archives/C5PG2JK8W) channel on the public Grafana Slack.
+For general discussions about documentation, you’re welcome to join the [#docs](https://raintank-corp.slack.com/archives/C5PG2JK8W) channel on the public Grafana Labs Slack workspace.

--- a/vale/Grafana/DocumentationTeam.yml
+++ b/vale/Grafana/DocumentationTeam.yml
@@ -5,4 +5,4 @@ message: Use '%s' rather than '%s'.
 action:
   name: replace
 swap:
-  "[Dd]ocs (?:[Ss]quad|[Tt]eam)": the Grafana Labs documentation team
+  "[Dd]ocs? (?:[Ss]quad|[Tt]eam)": the Grafana Labs documentation team


### PR DESCRIPTION
[Review home page](https://github.com/grafana/writers-toolkit/commit/b08472eb24b0790e6dbc2cad8860eca3fff3c775) 

Update description to give more context.

Closes #651 

[Review Contribute page](https://github.com/grafana/writers-toolkit/commit/3cfe7e57876833db7dafe3834dc1f96b039a9dfa) 

- Correctly refer to the Grafana Labs documentation team instead of Doc Squad
- Clarify that documentation without a **Suggest an Edit** link is closed source
- Avoid gerund

Closes #652 

[Review Introduction page](https://github.com/grafana/writers-toolkit/commit/c5ec2fa5c4b6d8b4c47fae00fe9513358d9d4737) 

- Update links to some open source projects
- Prefer full URLs
- Prefer Grafana Labs over Grafana

Closes #653 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>