### PR TITLE
Review 'Lint prose' page

### DIFF
--- a/docs/make-docs
+++ b/docs/make-docs
@@ -6,6 +6,17 @@
 # [Semantic versioning](https://semver.org/) is used to help the reader identify the significance of changes.
 # Changes are relevant to this script and the support docs.mk GNU Make interface.
 #
+# ## 8.0.0 (2024-05-28)
+#
+# ### Changed
+#
+# - Add environment variable `OUTPUT_FORMAT` to control the output of commands.
+#
+#   The default value is `human` and means the output format is human readable.
+#   The value `json` is also supported and outputs JSON.
+#
+#   Note that the `json` format isn't supported by `make docs`, only `make doc-validator` and `make vale`.
+#
 # ## 7.0.0 (2024-05-03)
 #
 # ### Changed
@@ -254,6 +265,8 @@ readonly DOC_VALIDATOR_SKIP_CHECKS="${DOC_VALIDATOR_SKIP_CHECKS:-^image-}"
 readonly HUGO_REFLINKSERRORLEVEL="${HUGO_REFLINKSERRORLEVEL:-WARNING}"
 readonly VALE_MINALERTLEVEL="${VALE_MINALERTLEVEL:-error}"
 readonly WEBSITE_EXEC="${WEBSITE_EXEC:-make server-docs}"
+
+readonly OUTPUT_FORMAT="${OUTPUT_FORMAT:-human}"
 
 PODMAN="$(if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)"
 
@@ -748,45 +761,74 @@ POSIX_HERESTRING
 
 case "${image}" in
   'grafana/doc-validator')
-    if ! command -v jq >/dev/null 2>&1; then
-      errr '`jq` must be installed for the `doc-validator` target to work.'
-      note 'To install `jq`, refer to https://jqlang.github.io/jq/download/,'
-
-      exit 1
-    fi
-
     proj="$(new_proj "$1")"
     printf '\r\n'
-    "${PODMAN}" run \
+
+    IFS='' read -r cmd <<EOF
+    ${PODMAN} run \
                 --init \
                 --interactive \
                 --platform linux/amd64 \
                 --rm \
                 --tty \
                 ${volumes} \
-                "${DOCS_IMAGE}" \
-                "--include=${DOC_VALIDATOR_INCLUDE}" \
-                "--skip-checks=${DOC_VALIDATOR_SKIP_CHECKS}" \
-                "/hugo/content$(proj_canonical "${proj}")" \
-                "$(proj_canonical "${proj}")" \
-                | sed "s#$(proj_dst "${proj}")#sources#" \
-                | jq -r '"ERROR: \(.location.path):\(.location.range.start.line // 1):\(.location.range.start.column // 1): \(.message)" + if .suggestions[0].text then "\nSuggestion: \(.suggestions[0].text)" else "" end'
+                ${DOCS_IMAGE} \
+                --include=${DOC_VALIDATOR_INCLUDE} \
+                --skip-checks=${DOC_VALIDATOR_SKIP_CHECKS} \
+                /hugo/content$(proj_canonical "${proj}") \
+                "$(proj_canonical "${proj}") \
+                | sed "s#$(proj_dst "${proj}")#sources#"
+EOF
+
+    case "${OUTPUT_FORMAT}" in
+      human)
+        if ! command -v jq >/dev/null 2>&1; then
+          errr '`jq` must be installed for the `doc-validator` target to work.'
+          note 'To install `jq`, refer to https://jqlang.github.io/jq/download/,'
+
+          exit 1
+        fi
+
+        ${cmd} \
+        | jq -r '"ERROR: \(.location.path):\(.location.range.start.line // 1):\(.location.range.start.column // 1): \(.message)" + if .suggestions[0].text then "\nSuggestion: \(.suggestions[0].text)" else "" end'
+      ;;
+      json)
+        ${cmd}
+      ;;
+      *)  # default
+        errr "Invalid output format '${OUTPUT_FORMAT}'"
+    esac
     ;;
   'grafana/vale')
     proj="$(new_proj "$1")"
     printf '\r\n'
-    "${PODMAN}" run \
+    IFS='' read -r cmd <<EOF
+    ${PODMAN} run \
                 --init \
                 --interactive \
                 --rm \
                 --workdir /etc/vale \
                 --tty \
                 ${volumes} \
-                "${DOCS_IMAGE}" \
-                "--minAlertLevel=${VALE_MINALERTLEVEL}" \
-                '--glob=*.md' \
-                --output=/etc/vale/rdjsonl.tmpl \
-                /hugo/content/docs | sed "s#$(proj_dst "${proj}")#sources#"
+                ${DOCS_IMAGE} \
+                --minAlertLevel=${VALE_MINALERTLEVEL} \
+                --glob=*.md \
+                /hugo/content/docs
+EOF
+
+    case "${OUTPUT_FORMAT}" in
+      human)
+        ${cmd} --output=line \
+        | sed "s#$(proj_dst "${proj}")#sources#"
+      ;;
+      json)
+        ${cmd} --output=/etc/vale/rdjsonl.tmpl \
+        | sed "s#$(proj_dst "${proj}")#sources#"
+      ;;
+      *)
+        errr "Invalid output format '${OUTPUT_FORMAT}'"
+    esac
+
     ;;
   *)
     tempfile="$(mktemp -t make-docs.XXX)"

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/lint-prose/
   - /docs/writers-toolkit/review/lint-prose/
 date: 2024-02-21
-description: How to lint prose with the Vale linter.
+description: How to lint prose for Grafana Labs style with the Vale linter.
 menuTitle: Lint prose
 title: Lint prose with the Vale linter
 weight: 300

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -149,24 +149,3 @@ The extension reports the linting results in two ways:
   You can hover your mouse cursor over the edit marks to view the Vale warning or error.
 - A full report in the **PROBLEMS** tab.
   Each Vale warning or error in the report includes the line and column where the error occurs.
-
-## Vale error output
-
-When you write something that has an associated rule in one of the Vale linting files, Vale outputs an error, such as:
-
-`Use '%s' instead of '%s'.`
-
-`Did you mean '%s' instead of '%s'?`
-
-Most of these error messages and suggestions are self-explanatory and include preferred spellings or alternate words.
-However, the following rules require further explanation:
-
-### Allows to
-
-<!-- vale Grafana.AllowsTo = NO -->
-<!-- This section explains the specific rule with examples. -->
-
-Common wording error.
-The linter suggests replacing "allows to" to with the grammatically correct "allows you to", since there is no use case for the phrase "allows to".
-
-<!-- vale Grafana.AllowsTo = YES -->

--- a/vale/Grafana/AllowsTo.yml
+++ b/vale/Grafana/AllowsTo.yml
@@ -3,7 +3,6 @@ message: |
   Did you mean '%s' instead of '%s'?
 
   Allows to is a common wording error.
-link: https://grafana.com/docs/writers-toolkit/word-list#allows-to
 level: warning
 ignorecase: false
 action:

--- a/vale/Grafana/AllowsTo.yml
+++ b/vale/Grafana/AllowsTo.yml
@@ -1,5 +1,8 @@
 extends: substitution
-message: Did you mean '%s' instead of '%s'?
+message: |
+  Did you mean '%s' instead of '%s'?
+
+  Allows to is a common wording error.
 link: https://grafana.com/docs/writers-toolkit/word-list#allows-to
 level: warning
 ignorecase: false


### PR DESCRIPTION
- Avoid needing to explain the `Grafana/AllowsTo` rule in the documentation.
- Add context in page description
- Present human readable output when users run `make vale`

Closes https://github.com/grafana/writers-toolkit/issues/679

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>