### PR TITLE
Replace date front matter with review_date

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -11,7 +11,7 @@ cascade:
   github_branch: main
   github_dir: /docs/sources
   replace_dir: docs/writers-toolkit/
-date: 2024-05-16
+review_date: 2024-05-16
 description: |
   A toolkit for writing technical documentation for Grafana Labs.
   Use it as the source of truth for voice and tone, grammar, style, templates, and more.

--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/contribute/
   - /docs/writers-toolkit/contribute-documentation/
   - /docs/writers-toolkit/writing-guide/contribute-documentation/
-date: 2024-05-16
+review_date: 2024-05-16
 description: Learn how you can contribute to Grafana Labs documentation.
 keywords:
   - contribute

--- a/docs/sources/contribute/release-notes/index.md
+++ b/docs/sources/contribute/release-notes/index.md
@@ -4,7 +4,7 @@ aliases:
   - /docs/writers-toolkit/contribute-release-notes/
   - /docs/writers-toolkit/contribute/release-notes/
   - /docs/writers-toolkit/writing-guide/contribute-documentation/contribute-release-notes/
-date: 2024-05-16
+review_date: 2024-05-16
 description: Learn the different ways of contributing to the Grafana Labs What's new document and Grafana release notes.
 keywords:
   - what's new

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/get-started/
 description: Everything you need to complete your documentation project from start to finish.
-date: 2024-05-22
+review_date: 2024-05-22
 menuTitle: Get started
 title: Get started with writing documentation
 weight: 50

--- a/docs/sources/introduction/index.md
+++ b/docs/sources/introduction/index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/about-grafana-docs/
   - /docs/writers-toolkit/introduction/
   - /docs/writers-toolkit/writing-guide/about-grafana-docs/
-date: 2024-05-16
+review_date: 2024-05-16
 description: Learn about how Grafana Labs manages technical documentation.
 keywords:
   - Grafana

--- a/docs/sources/review/_index.md
+++ b/docs/sources/review/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/
   - /docs/writers-toolkit/review/
-date: 2024-05-22
+review_date: 2024-05-22
 description: Build and review your content locally. Learn how to use documentation tools and understand our workflows.
 keywords:
   - build

--- a/docs/sources/review/backport-changes/index.md
+++ b/docs/sources/review/backport-changes/index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/review/backport-changes/
   - /docs/writers-toolkit/review/backporting/
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/backporting/
-date: 2024-05-22
+review_date: 2024-05-22
 description: Understand how and when to backport changes to Grafana repositories.
 keywords:
   - backporting

--- a/docs/sources/review/cla-assistant/index.md
+++ b/docs/sources/review/cla-assistant/index.md
@@ -1,6 +1,6 @@
 ---
 description: Understand the CLA assistant and its use on GitHub pull requests in Grafana repositories.
-date: 2024-05-23
+review_date: 2024-05-23
 menuTitle: CLA assistant
 title: Contributor License Agreement (CLA) assistant
 ---

--- a/docs/sources/review/doc-validator/_index.md
+++ b/docs/sources/review/doc-validator/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/validate-technical-documentation/
   - /docs/writers-toolkit/review/doc-validator/
-date: 2024-05-23
+review_date: 2024-05-23
 description: How to validate Grafana Labs technical documentation with the doc-validator tool.
 menuTitle: Automated validation
 title: Automated validation with doc-validator

--- a/docs/sources/review/doc-validator/errata.md
+++ b/docs/sources/review/doc-validator/errata.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/validate-technical-documentation/errata/
   - /docs/writers-toolkit/review/doc-validator/errata/
-date: 2024-05-23
+review_date: 2024-05-23
 description: A reference of error codes and descriptions reported by doc-validator when linting Grafana Labs technical documentation.
 title: Errata for doc-validator
 ---

--- a/docs/sources/review/lint-prose/index.md
+++ b/docs/sources/review/lint-prose/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/lint-prose/
   - /docs/writers-toolkit/review/lint-prose/
-date: 2024-05-28
+review_date: 2024-05-28
 description: How to lint prose for Grafana Labs style with the Vale linter.
 menuTitle: Lint prose
 title: Lint prose with the Vale linter

--- a/docs/sources/review/test-documentation-changes/index.md
+++ b/docs/sources/review/test-documentation-changes/index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/review/run-a-local-webserver/
   - /docs/writers-toolkit/review/test-documentation-changes/
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/run-a-local-webserver/
-date: 2024-05-28
+review_date: 2024-05-28
 description: Test documentation changes by running a local documentation web server
 title: Test documentation changes
 weight: 200

--- a/docs/sources/shared/hugo-error-example-bad-link.md
+++ b/docs/sources/shared/hugo-error-example-bad-link.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-05-28
+review_date: 2024-05-28
 description: Understand the REF_NOT_FOUND error Hugo emits for broken relref links.
 title: REF_NOT_FOUND Hugo output
 ---

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,5 +1,5 @@
 ---
 headless: true
 description: Only required to make the children of this page available as resources.
-date: 2024-02-22
+review_date: 2024-02-22
 ---

--- a/docs/sources/shared/make-help.md
+++ b/docs/sources/shared/make-help.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-02-23
+review_date: 2024-02-23
 description: Understand GNU Make and see and example of Make targets.
 title: GNU Make help output
 ---

--- a/docs/sources/shared/refs-example.md
+++ b/docs/sources/shared/refs-example.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-03-18
+review_date: 2024-03-18
 description: An example of the `refs` front matter.
 title: An example of the `refs` front matter
 ---

--- a/docs/sources/structure/_index.md
+++ b/docs/sources/structure/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/
   - /docs/writers-toolkit/structure
-date: 2024-02-26
+review_date: 2024-02-26
 description: How to organize concepts and tasks in the repository.
 keywords:
   - information architecture

--- a/docs/sources/structure/about-documentation-design/index.md
+++ b/docs/sources/structure/about-documentation-design/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/about-documentation-design/
   - /docs/writers-toolkit/structure/about-documentation-design/
-date: 2024-02-26
+review_date: 2024-02-26
 description: Learn about the design of Grafana's documentation pages
 keywords:
   - Grafana

--- a/docs/sources/structure/topic-types/_index.md
+++ b/docs/sources/structure/topic-types/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/topic-types/
   - /docs/writers-toolkit/structure/topic-types/
-date: 2024-02-13
+review_date: 2024-02-13
 description: Learn to write different types of topics.
 keywords:
   - topic types

--- a/docs/sources/structure/topic-types/concept/index.md
+++ b/docs/sources/structure/topic-types/concept/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/topic-types/concept
   - /docs/writers-toolkit/structure/topic-types/concept
-date: 2024-02-26
+review_date: 2024-02-26
 description: Learn how to write a concept topic.
 keywords:
   - topic types

--- a/docs/sources/structure/topic-types/reference/index.md
+++ b/docs/sources/structure/topic-types/reference/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/topic-types/reference
   - /docs/writers-toolkit/structure/topic-types/reference/
-date: 2024-02-27
+review_date: 2024-02-27
 description: Learn how to write a reference topic.
 keywords:
   - topic types

--- a/docs/sources/structure/topic-types/task/index.md
+++ b/docs/sources/structure/topic-types/task/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/topic-types/task
   - /docs/writers-toolkit/structure/topic-types/task/
-date: 2024-02-27
+review_date: 2024-02-27
 description: Learn how to write a task topic.
 keywords:
   - topic types

--- a/docs/sources/structure/topic-types/tutorial/index.md
+++ b/docs/sources/structure/topic-types/tutorial/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/documentation-structure/topic-types/tutorial
   - /docs/writers-toolkit/structure/topic-types/tutorial/
-date: 2024-02-29
+review_date: 2024-02-29
 description: Learn how to write a tutorial topic.
 keywords:
   - topic types

--- a/docs/sources/structure/topic-types/visualization/index.md
+++ b/docs/sources/structure/topic-types/visualization/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - /docs/writers-toolkit/structure/topic-types/visualization
-date: 2024-02-29
+review_date: 2024-02-29
 description: Learn how to write a visualization topic.
 keywords:
   - topic types

--- a/docs/sources/write/_index.md
+++ b/docs/sources/write/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/
   - /docs/writers-toolkit/write/
-date: 2024-03-14
+review_date: 2024-03-14
 description: Learn about Grafana Labs' technical documentation writing guidelines.
 keywords:
   - writing

--- a/docs/sources/write/deprecate-remove/index.md
+++ b/docs/sources/write/deprecate-remove/index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - /docs/writers-toolkit/write/deprecate-remove/
-date: 2024-05-16
+review_date: 2024-05-16
 description: Learn about deprecating or removing content in your documentation.
 weight: 900
 keywords:

--- a/docs/sources/write/front-matter/index.md
+++ b/docs/sources/write/front-matter/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/front-matter/
   - /docs/writers-toolkit/write/front-matter/
-date: 2024-04-09
+review_date: 2024-04-09
 description: Learn about how Grafana builds front matter to properly enable the publication and search of our technical documentation.
 keywords:
   - front matter

--- a/docs/sources/write/image-guidelines/index.md
+++ b/docs/sources/write/image-guidelines/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/image-guidelines/
   - /docs/writers-toolkit/write/image-guidelines/
-date: 2024-02-13
+review_date: 2024-02-13
 description: How to include images and other media in your documentation.
 keywords:
   - image

--- a/docs/sources/write/links/_index.md
+++ b/docs/sources/write/links/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/write/links/
   - /docs/writers-toolkit/write/references/
   - /docs/writers-toolkit/writing-guide/references/
-date: 2024-02-15
+review_date: 2024-02-15
 description: Understand how to link between pages.
 keywords:
   - Hugo

--- a/docs/sources/write/links/useful-link-text.md
+++ b/docs/sources/write/links/useful-link-text.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/write/style-guide/useful-link-text/
   - /docs/writers-toolkit/write/useful-link-text/
 description: Learn how to write useful link text.
-date: 2024-04-15
+review_date: 2024-04-15
 title: Write useful link text
 ---
 

--- a/docs/sources/write/markdown-guide/index.md
+++ b/docs/sources/write/markdown-guide/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/markdown-guide/
   - /docs/writers-toolkit/write/markdown-guide/
-date: 2024-02-13
+review_date: 2024-02-13
 description: Guidelines for writing technical documentation in Markdown.
 keywords:
   - Markdown

--- a/docs/sources/write/reuse-content/_index.md
+++ b/docs/sources/write/reuse-content/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - /docs/writers-toolkit/write/reuse-content/
-date: 2024-04-09
+review_date: 2024-04-09
 description: Learn about reusing content in your documentation.
 keywords:
   - sharing

--- a/docs/sources/write/reuse-content/reuse-directories/index.md
+++ b/docs/sources/write/reuse-content/reuse-directories/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/reuse-directories/
   - /docs/writers-toolkit/write/reuse-content/reuse-directories/
-date: 2024-03-14
+review_date: 2024-03-14
 description: Learn to reuse directories of content with Hugo mounts.
 keywords:
   - content reuse

--- a/docs/sources/write/reuse-content/reuse-shared-content/index.md
+++ b/docs/sources/write/reuse-content/reuse-shared-content/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/reuse-shared-content/
   - /docs/writers-toolkit/write/reuse-content/reuse-shared-content/
-date: 2024-03-14
+review_date: 2024-03-14
 description: Learn to reuse chunks of content between pages.
 keywords:
   - content reuse

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/write/shortcodes/
   - /docs/writers-toolkit/writing-guide/shortcodes/
-date: 2024-04-15
+review_date: 2024-04-15
 description: Understand what shortcodes are and how to use them in your Markdown.
 keywords:
   - Hugo

--- a/docs/sources/write/style-guide/_index.md
+++ b/docs/sources/write/style-guide/_index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/style-guide/
   - /docs/writers-toolkit/write/style-guide
-date: 2024-02-13
+review_date: 2024-02-13
 description: Style guide for Grafana Labs
 keywords:
   - Grafana

--- a/docs/sources/write/style-guide/capitalization-punctuation/index.md
+++ b/docs/sources/write/style-guide/capitalization-punctuation/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/style-guide/capitalization-punctuation
   - /docs/writers-toolkit/write/style-guide/capitalization-punctuation
-date: 2024-04-15
+review_date: 2024-04-15
 description: Guidelines for use of capitalization and punctuation.
 keywords:
   - capitalization

--- a/docs/sources/write/style-guide/style-conventions/index.md
+++ b/docs/sources/write/style-guide/style-conventions/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/style-guide/style-conventions
   - /docs/writers-toolkit/write/style-guide/style-conventions
-date: 2024-05-16
+review_date: 2024-05-16
 description: A non-exhaustive list of technical writing techniques and styles you should consider when you write technical documentation for Grafana Labs.
 keywords:
   - style conventions

--- a/docs/sources/write/style-guide/ui-elements/index.md
+++ b/docs/sources/write/style-guide/ui-elements/index.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-05-16
+review_date: 2024-05-16
 description: Guidelines for referring to UI elements in Grafana documentation.
 keywords:
   - Grafana

--- a/docs/sources/write/style-guide/voice-tone-guidelines/index.md
+++ b/docs/sources/write/style-guide/voice-tone-guidelines/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/style-guide/voice-tone-guidelines
   - /docs/writers-toolkit/write/style-guide/voice-tone-guidelines
-date: 2024-03-14
+review_date: 2024-03-14
 description: Guidelines for voice and tone in Grafana Labs' documentation.
 keywords:
   - Grafana

--- a/docs/sources/write/tooling-and-workflows/index.md
+++ b/docs/sources/write/tooling-and-workflows/index.md
@@ -2,7 +2,7 @@
 aliases:
   - /docs/writers-toolkit/writing-guide/tooling-and-workflows/
   - /docs/writers-toolkit/write/tooling-and-workflows/
-date: 2024-04-08
+review_date: 2024-04-08
 description: Build and review your content locally; learn how to use documentation tools and understand our workflows.
 keywords:
   - git

--- a/tools/cmd/review/main.go
+++ b/tools/cmd/review/main.go
@@ -43,8 +43,8 @@ func (d *DateArgument) Set(str string) error {
 }
 
 type metadata struct {
-	Date     time.Time `yaml:"date"`
-	Headless bool      `yaml:"headless"`
+	ReviewDate time.Time `yaml:"review_date"`
+	Headless   bool      `yaml:"headless"`
 }
 
 func main() {
@@ -103,7 +103,7 @@ func main() {
 			return fmt.Errorf("unable to unmarshal front matter in %q: %w", path, err)
 		}
 
-		if frontMatter.Date.Before(before.time) && !frontMatter.Headless {
+		if frontMatter.ReviewDate.Before(before.time) && !frontMatter.Headless {
 			pages = append(pages, path)
 		}
 


### PR DESCRIPTION
> The date field in front matter is often considered to be the creation date, You can change its meaning, and its effect on your site, in the site configuration. See details.

https://gohugo.io/methods/page/date/#:~:text=The%20date%20field%20in%20front,Time%20value.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>