### PR TITLE
Review 'GNU Make help output' shared page

### DIFF
--- a/docs/sources/shared/make-help.md
+++ b/docs/sources/shared/make-help.md
@@ -1,10 +1,10 @@
 ---
-review_date: 2024-02-23
 description: Understand GNU Make and see and example of Make targets.
+review_date: 2024-05-29
 title: GNU Make help output
 ---
 
-Every project keeps technical documentation in the `docs/sources` directory.
+Every project keeps technical documentation that's published to the website in the `docs/sources` directory.
 Additionally, every project uses [GNU Make](https://www.gnu.org/software/make/) to perform tasks related to technical documentation.
 To learn more about GNU Make, refer to [GNU Make Manual](https://www.gnu.org/software/make/manual/).
 
@@ -20,10 +20,9 @@ Targets:
   docs-rm          Remove the docs container.
   docs-pull        Pull documentation base image.
   make-docs        Fetch the latest make-docs script.
-  docs             Serve documentation locally, which includes pulling the latest `DOCS_IMAGE` (default: `grafana/docs-base:latest`) container image. See also `docs-no-pull`.
-  docs-no-pull     Serve documentation locally without pulling the `DOCS_IMAGE` (default: `grafana/docs-base:latest`) container image.
+  docs             Serve documentation locally, which includes pulling the latest `DOCS_IMAGE` (default: `grafana/docs-base:latest`) container image. To not pull the image, set `PULL=false`.
   docs-debug       Run Hugo web server with debugging enabled. TODO: support all SERVER_FLAGS defined in website Makefile.
-  doc-validator    Run doc-validator on the entire docs folder.
-  vale             Run vale on the entire docs folder.
+  doc-validator    Run doc-validator on the entire docs folder which includes pulling the latest `DOC_VALIDATOR_IMAGE` (default: `grafana/doc-validator:latest`) container image. To not pull the image, set `PULL=false`.
+  vale             Run vale on the entire docs folder which includes pulling the latest `VALE_IMAGE` (default: `grafana/vale:latest`) container image. To not pull the image, set `PULL=false`.
   update           Fetch the latest version of this Makefile and the `make-docs` script from Writers' Toolkit.
 ```


### PR DESCRIPTION
- Clarify that website technical documentation lives in `/docs/sources` (EngHub technical documentation lives elsewhere)
- Update `make help` output

Rest LGTM

Closes https://github.com/grafana/writers-toolkit/issues/687