### PR TITLE
Add scheduler to dictionary with possessive affix rules

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-210
+211
 ACL/S po:noun
 Aerospike/ po:noun
 Agent/ po:noun
@@ -149,6 +149,7 @@ Rollup/ po:noun
 RSA/ po:noun
 runbook/S po:noun
 sandbox/DG po:verb
+scheduler/MS po:noun
 SCM/ po:noun
 SCSS/ po:noun
 SDK/S po:noun

--- a/vale/dictionary.jsonnet
+++ b/vale/dictionary.jsonnet
@@ -179,6 +179,7 @@ local newWord(word, affixes, po) = {
     newWord('RSA', '', 'noun') { acronym: true, established_acronym: true },
     newWord('runbook', 'S', 'noun'),
     newWord('sandbox', 'DG', 'verb'),
+    newWord('scheduler', 'MS', 'noun') { description: 'A Kubernetes component that schedules workloads' },
     newWord('SCM', '', 'noun') { acronym: true, established_acronym: true },
     newWord('SCSS', '', 'noun') { acronym: true, established_acronym: true },
     newWord('SDK', 'S', 'noun') { acronym: true, established_acronym: true },


### PR DESCRIPTION
https://www.google.com/search?q=%22scheduler%27s%22+site%3Akubernetes.io&sca_esv=e8add49ad30124b6&ei=-h1YZrmLBoKmhbIPlvO0uAs&ved=0ahUKEwi58KX74LSGAxUCU0EAHZY5DbcQ4dUDCBA&uact=5&oq=%22scheduler%27s%22+site%3Akubernetes.io&gs_lp=Egxnd3Mtd2l6LXNlcnAiICJzY2hlZHVsZXIncyIgc2l0ZTprdWJlcm5ldGVzLmlvSPYOUIQCWOEMcAF4AJABAJgBM6ABjgGqAQEzuAEDyAEA-AEBmAIAoAIAmAMAiAYBkgcAoAeHAQ&sclient=gws-wiz-serp

https://github.com/grafana/website/pull/19964/files#r1618992079