### PR TITLE
Add windows_exporter to dictionary

### DIFF
--- a/vale/dictionaries/en_US-grafana.dic
+++ b/vale/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-210
+211
 ACL/S po:noun
 Aerospike/ po:noun
 Agent/ po:noun
@@ -202,6 +202,7 @@ WAL/S po:noun
 walkthrough/S po:noun
 Webpack/ po:noun
 webserver/S po:noun
+windows_exporter/S po:noun
 worktree/ po:noun
 XML/ po:noun
 XSS/ po:noun

--- a/vale/dictionary.jsonnet
+++ b/vale/dictionary.jsonnet
@@ -232,6 +232,7 @@ local newWord(word, affixes, po) = {
     newWord('walkthrough', 'S', 'noun'),
     newWord('Webpack', '', 'noun'),
     newWord('webserver', 'S', 'noun'),
+    newWord('windows_exporter', 'S', 'noun') { description: 'The Prometheus exporter for Windows machines (https://github.com/prometheus-community/windows_exporter)', product: true },
     newWord('worktree', '', 'noun'),
     newWord('XML', '', 'noun') { acronym: true, established_acronym: true },
     newWord('XSS', '', 'noun') { acronym: true },


### PR DESCRIPTION
It looks like the docs use [windows_exporter](https://github.com/prometheus-community/windows_exporter) pretty consistently.