### PR TITLE
Add Vale rule to lint for writing specific shortcodes with percent syntax

### DIFF
--- a/vale/Grafana/Shortcodes.yml
+++ b/vale/Grafana/Shortcodes.yml
@@ -1,0 +1,18 @@
+extends: script
+message: |
+  Use `{{<` and `>}}` instead of `{{%%` and `%%}}`.
+
+  The former has the most consistent semantics.
+
+  The latter is used for special behavior that isn't required with this shortcode.
+link: https://grafana.com/docs/writers-toolkit/write/shortcodes/#admonition
+scope: raw
+script: |
+  text := import("text")
+
+  matches := []
+
+  for match in text.re_find(`{{% +/?admonition .*%}}`, scope, -1) {
+      matches = append(matches, {begin: match[0].begin, end: match[0].end})
+    }
+  }

--- a/vale/fixtures/Grafana/Shortcodes/.vale.ini
+++ b/vale/fixtures/Grafana/Shortcodes/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../../
+MinAlertLevel = suggestion
+[*.md]
+Grafana.Shortcodes = YES

--- a/vale/fixtures/Grafana/Shortcodes/testinvalid.golden
+++ b/vale/fixtures/Grafana/Shortcodes/testinvalid.golden
@@ -1,0 +1,5 @@
+testinvalid.md:3:3:Grafana.Shortcodes:Use `{{<` and `>}}` instead of `{{%` and `%}}`. The former has the most consistent semantics. The latter is used for special behavior that isn't required with this shortcode. 
+testinvalid.md:4:3:Grafana.Shortcodes:Use `{{<` and `>}}` instead of `{{%` and `%}}`. The former has the most consistent semantics. The latter is used for special behavior that isn't required with this shortcode. 
+testinvalid.md:5:3:Grafana.Shortcodes:Use `{{<` and `>}}` instead of `{{%` and `%}}`. The former has the most consistent semantics. The latter is used for special behavior that isn't required with this shortcode. 
+testinvalid.md:6:3:Grafana.Shortcodes:Use `{{<` and `>}}` instead of `{{%` and `%}}`. The former has the most consistent semantics. The latter is used for special behavior that isn't required with this shortcode. 
+testinvalid.md:7:3:Grafana.Shortcodes:Use `{{<` and `>}}` instead of `{{%` and `%}}`. The former has the most consistent semantics. The latter is used for special behavior that isn't required with this shortcode. 

--- a/vale/fixtures/Grafana/Shortcodes/testinvalid.md
+++ b/vale/fixtures/Grafana/Shortcodes/testinvalid.md
@@ -1,0 +1,7 @@
+Don't use:
+
+- {{% admonition type="caution" %}}
+- {{% admonition type="note" %}}
+- {{% admonition type="tip" %}}
+- {{% admonition type="warn" %}}
+- {{% /admonition %}}

--- a/vale/fixtures/Grafana/Shortcodes/testvalid.md
+++ b/vale/fixtures/Grafana/Shortcodes/testvalid.md
@@ -1,0 +1,7 @@
+Instead use:
+
+- {{< admonition type="caution" >}}
+- {{< admonition type="note" >}}
+- {{< admonition type="tip" >}}
+- {{< admonition type="warn" >}}
+- {{< /admonition >}}


### PR DESCRIPTION
In most cases, it isn't needed.
For consistency and pattern matching, we should prefer {{< because it better reflects the shortcode semantics we default to in our minds.

The other syntax is only necessary in specific contexts and the nuances are complicated.