### PR TITLE
Include word in issue title for spelling false positive 

### DIFF
--- a/vale/Grafana/Spelling.yml
+++ b/vale/Grafana/Spelling.yml
@@ -4,7 +4,7 @@ message: |
 
   For product names, the Grafana dictionary might not know of it yet.
   You need to add an entry to https://github.com/grafana/writers-toolkit/tree/main/vale/dictionary.jsonnet to add a product name to the dictionary.
-  Alternatively, raise an [issue](https://github.com/grafana/writers-toolkit/issues/new?title=Grafana.Spelling%20%3A%20%3CWORD%3E) and a maintainer will add it for you.
+  Alternatively, raise an [issue](https://github.com/grafana/writers-toolkit/issues/new?title=Grafana.Spelling%%3A%%20%[1]s) and a maintainer will add it for you.
 
   For UI elements, use [bold formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
   The spell checker doesn't check words with bold formatting.


### PR DESCRIPTION
Bonus, fix the link that was broken. Reported by Beverly.

Will drop [0e81a8a](https://github.com/grafana/writers-toolkit/pull/709/commits/0e81a8a29c4ea161abed7cedb4dd8ad35b0bea3c) before merging which was used to demonstrate the fixed behavior in https://github.com/grafana/writers-toolkit/pull/709#discussion_r1625448068