### PR TITLE
Add Vale rule to lint for http://grafana.com links

### DIFF
--- a/vale/Grafana/HTTP.yml
+++ b/vale/Grafana/HTTP.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: |
+  Use '%s' instead of '%s'.
+
+  The HTTP scheme is insecure and all grafana.com links must use HTTPS.
+level: error
+action:
+  name: replace
+scope: raw
+swap:
+  'http://grafana.com': 'https://grafana.com'

--- a/vale/fixtures/Grafana/HTTP/.vale.ini
+++ b/vale/fixtures/Grafana/HTTP/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../../
+MinAlertLevel = suggestion
+[*.md]
+Grafana.HTTP = YES

--- a/vale/fixtures/Grafana/HTTP/testinvalid.golden
+++ b/vale/fixtures/Grafana/HTTP/testinvalid.golden
@@ -1,0 +1,2 @@
+testinvalid.md:3:4:Grafana.HTTP:Use 'https://grafana.com' instead of 'http://grafana.com'. The HTTP scheme is insecure and all grafana.com links must use HTTPS. 
+testinvalid.md:4:15:Grafana.HTTP:Use 'https://grafana.com' instead of 'http://grafana.com'. The HTTP scheme is insecure and all grafana.com links must use HTTPS. 

--- a/vale/fixtures/Grafana/HTTP/testinvalid.md
+++ b/vale/fixtures/Grafana/HTTP/testinvalid.md
@@ -1,0 +1,4 @@
+Don't use:
+
+- <http://grafana.com>
+- [link text](http://grafana.com)

--- a/vale/fixtures/Grafana/HTTP/testvalid.md
+++ b/vale/fixtures/Grafana/HTTP/testvalid.md
@@ -1,0 +1,4 @@
+Instead use:
+
+- <https://grafana.com>
+- [link text](https://grafana.com)


### PR DESCRIPTION
We must use HTTPS to be secure.