### PR TITLE
Revert "Docs: remove to do note"

### DIFF
--- a/docs/sources/structure/topic-types/visualization/index.md
+++ b/docs/sources/structure/topic-types/visualization/index.md
@@ -144,6 +144,8 @@ To write a visualization or widget topic, follow these steps.
 
    For more information about front matter, refer to [Front matter](https://grafana.com/docs/writers-toolkit/write/front-matter/).
 
+<!-- https://github.com/grafana/writers-toolkit/issues/560 -->
+
 ## Visualization template
 
 When you're ready to write, make a copy of the [Visualization template](https://github.com/grafana/writers-toolkit/blob/main/docs/static/templates/visualization-template.md) and add your content.


### PR DESCRIPTION
Reverts grafana/writers-toolkit#732

I think the note is a useful reminder to review the issue. I think it can be removed when the issue is resolved, either as a won't do or when it's fixed.

It's this note that prompted me to bump the issue in Writers' Toolkit as I encountered it when reviewing the page for accuracy.