### PR TITLE
Allow 'kube-prometheus'

### DIFF
--- a/vale/Grafana/WordList.yml
+++ b/vale/Grafana/WordList.yml
@@ -85,7 +85,7 @@ swap:
   postgres: Postgres
   postgresql: PostgreSQL
   prom(?:ql|QL): PromQL
-  prometheus: Prometheus
+  "(?<!kube-)prometheus": Prometheus
   "(?<!lambda-)promtail": Promtail
   redis: Redis
   regex: regular expression


### PR DESCRIPTION
 Only insist on using `Prometheus` over `prometheus` if it isn't preceded by `kube-`
 
 https://github.com/prometheus-operator/kube-prometheus