### PR TITLE
Document duplicate heading ids and how to avoid them

### DIFF
--- a/docs/sources/write/markdown-guide/index.md
+++ b/docs/sources/write/markdown-guide/index.md
@@ -42,6 +42,18 @@ For the title of the page, use one `#`. For each child heading, use two `##` sym
 <!-- vale Grafana.Gerunds = NO -->
 <!-- A false positive because the noun heading looks like a gerund. -->
 
+### Identifiers
+
+Each heading has an auto-generated identifier that you can use to link to the heading within the page.
+To derive the generated identifier from a heading, refer to [Link to page headings](https://grafana.com/docs/writers-toolkit/write/links/#link-to-page-headings).
+
+You can also explicitly set the heading identifier.
+The following Markdown example sets the heading identifier to be `alternative-heading-id`:
+
+```markdown
+# Heading {#alternative-heading-id}
+```
+
 ### Heading don'ts
 
 <!-- vale Grafana.Gerunds = YES -->

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -568,7 +568,7 @@ To trigger a rebuild after changes to a source file, perform a trivial change to
 
 ### Shared files and headings
 
-Hugo renders the shortcode separately to the page. As a result, if the same heading exists in a shared file as well as in the page that includes it, they'll have the same heading identifier. This duplication of heading identifiers breaks the ability link to the headings properly.
+Hugo renders the shortcode separately to the page. As a result, if the same heading exists in a shared file and the page that includes it, they'll have the same heading identifier. This duplication of heading identifiers breaks the ability to link to the headings properly.
 
 To work around this, set a heading identifier in the shared file.
 If there are two shared files with the same heading, you only need to set a heading identifier in one of them.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -568,7 +568,7 @@ To trigger a rebuild after changes to a source file, perform a trivial change to
 
 ### Shared files and headings
 
-Hugo renders the shortcode separately to the page. As a result, if the same heading exists in a shared file as well as in the page that includes it, they'll have the same heading identifier. This duplication of heading identifiers breaks the ability link to the headings properly. 
+Hugo renders the shortcode separately to the page. As a result, if the same heading exists in a shared file as well as in the page that includes it, they'll have the same heading identifier. This duplication of heading identifiers breaks the ability link to the headings properly.
 
 To work around this, set a heading identifier in the shared file.
 If there are two shared files with the same heading, you only need to set a heading identifier in one of them.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -566,13 +566,13 @@ Hugo doesn't rebuild the destination file when a source file changes on disk.
 To trigger a rebuild after changes to a source file, perform a trivial change to the destination file and save that, too.
 {{< /admonition >}}
 
-{{< admonition type="note" >}}
-Hugo renders the shortcode separately to the page.
-If the same heading exists in a shared file and in the page that includes it, they'll have the same heading identifier.
+### Shared files and headings
 
-To work around this, set the heading identifier in the shared file.
+Hugo renders the shortcode separately to the page. As a result, if the same heading exists in a shared file as well as in the page that includes it, they'll have the same heading identifier. This duplication of heading identifiers breaks the ability link to the headings properly. 
+
+To work around this, set a heading identifier in the shared file.
+If there are two shared files with the same heading, you only need to set a heading identifier in one of them.
 To set a heading identifier, refer to the [Markdown guide](https://grafana.com/docs/writers-toolkit/write/markdown-guide/#identifiers).
-{{< /admonition >}}
 
 ### Guidance
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -566,6 +566,14 @@ Hugo doesn't rebuild the destination file when a source file changes on disk.
 To trigger a rebuild after changes to a source file, perform a trivial change to the destination file and save that, too.
 {{< /admonition >}}
 
+{{< admonition type="note" >}}
+Hugo renders the shortcode separately to the page.
+If the same heading exists in a shared file and in the page that includes it, they'll have the same heading identifier.
+
+To work around this, set the heading identifier in the shared file.
+To set a heading identifier, refer to the [Markdown guide](https://grafana.com/docs/writers-toolkit/write/markdown-guide/#identifiers).
+{{< /admonition >}}
+
 ### Guidance
 
 When the page with the `docs/shared` shortcode includes a shared page from the same project, you should use version substitution syntax for the `version` parameter.


### PR DESCRIPTION
Duplicate headings only arise when using `docs/shared`.

This PR aims to explain why and how to work around it.