### PR TITLE
Fix link to guidance for dark and light mode

### DIFF
--- a/docs/sources/whats-new.md
+++ b/docs/sources/whats-new.md
@@ -20,8 +20,8 @@ This page provides a summary of notable changes to Writers' Toolkit guidance.
 
 ## August 2024
 
-| New guidance or change                                                                                  | Page                                                                                       |
-| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Revised Vale rule for use of exclamation marks and reduced its Vale severity from "error" to "warning". | [`Grafana.Exclamation`](/docs/writers-toolkit/review/lint-prose/rules/#grafanaexclamation) |
-| Added a What's new page used to summarize notable changes.                                              | [What's new](./)                                                                           |
-| Added guidance regarding dark and light mode for images.                                                | [Media guidelines](/docs/writers-toolkit/write/image-guidelines/#screenshot-guidelines-1)  |
+| New guidance or change                                                                                  | Page                                                                                          |
+| ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Revised Vale rule for use of exclamation marks and reduced its Vale severity from "error" to "warning". | [`Grafana.Exclamation`](/docs/writers-toolkit/review/lint-prose/rules/#grafanaexclamation)    |
+| Added a What's new page used to summarize notable changes.                                              | [What's new](./)                                                                              |
+| Added guidance regarding dark and light mode for images.                                                | [Media guidelines](/docs/writers-toolkit/write/image-guidelines/#image-and-diagram-standards) |


### PR DESCRIPTION
The original link goes to a different section that doesn't contain the guidance referenced.