### PR TITLE
Demote Grafana.GoogleOxfordComma to suggestion

### DIFF
--- a/docs/sources/review/lint-prose/rules.md
+++ b/docs/sources/review/lint-prose/rules.md
@@ -2,7 +2,7 @@
 date: "2024-06-25"
 description: A description of every Grafana Labs prose linting rule.
 menuTitle: Rules
-review_date: "2024-08-27"
+review_date: "2024-09-03"
 title: Vale rules
 ---
 
@@ -416,14 +416,6 @@ Don't put a period at the end of a heading.
 
 [More information ->](https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings)
 
-### Grafana.GoogleOxfordComma
-
-Extends: existence
-
-Use the Oxford comma in '%s'.
-
-[More information ->](https://developers.google.com/style/commas)
-
 ### Grafana.GoogleProductNames
 
 Extends: conditional
@@ -637,6 +629,14 @@ Extends: substitution
 Use '%s' instead of '%s'.
 
 [More information ->](https://developers.google.com/style/contractions)
+
+### Grafana.GoogleOxfordComma
+
+Extends: existence
+
+Use the Oxford comma in '%s'.
+
+[More information ->](https://developers.google.com/style/commas)
 
 ### Grafana.GooglePassive
 

--- a/vale/Grafana/GoogleOxfordComma.yml
+++ b/vale/Grafana/GoogleOxfordComma.yml
@@ -1,5 +1,5 @@
 "extends": "existence"
-"level": "warning"
+"level": "suggestion"
 "link": "https://developers.google.com/style/commas"
 "message": "Use the Oxford comma in '%s'."
 "scope": "sentence"

--- a/vale/google.jsonnet
+++ b/vale/google.jsonnet
@@ -23,7 +23,7 @@ std.prune({
   'Grafana/GoogleOptionalPlurals.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/OptionalPlurals.yml')),
   // Replaced by Grafana/Ordinal.yml.
   'Grafana/GoogleOrdinal.yml': null,
-  'Grafana/GoogleOxfordComma.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/OxfordComma.yml')),
+  'Grafana/GoogleOxfordComma.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/OxfordComma.yml') { level: 'suggestion' }),
   // Replaced by Grafana/Parentheses.yml.
   'Grafana/GoogleParens.yml': null,
   'Grafana/GooglePassive.yml': std.manifestYamlDoc(std.parseYaml(importstr 'Google/Passive.yml')),


### PR DESCRIPTION
There are too many false positives and this rule is easier to spot by eye than with regular expressions.

Closes https://github.com/grafana/writers-toolkit/issues/600