### PR TITLE
Add OpenAPI shortcodes documentation

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -414,7 +414,7 @@ This is rendered after the ignore.
 
 ## Docs/openapi/info
 
-Display information about an OpenAPI 3.0+ specification, use either the `url` or `data` parameter to specify an OpenAPI specification.
+Display information about an OpenAPI 3.0+ specification, use either the `url` or `data` parameter to specify an OpenAPI specification. Use the percentage shortcode tag `{{%/* */%}}` to include the content in the table of contents generation.
 
 | Parameter | Description                                                                                       | Required |
 | --------- | ------------------------------------------------------------------------------------------------- | -------- |
@@ -424,13 +424,13 @@ Display information about an OpenAPI 3.0+ specification, use either the `url` or
 To fetch a remote specification from a URL:
 
 ```markdown
-{{/*% docs/openapi/info url="<SPECIFICATION_URL>" %*/}}
+{{%/* docs/openapi/info url="<SPECIFICATION_URL>" */%}}
 ```
 
 To use a local specification from the website `data/docs/openapi/` directory:
 
 ```markdown
-{{/*% docs/openapi/info data="<SPECIFICATION_FILENAME>" %*/}}
+{{%/* docs/openapi/info data="<SPECIFICATION_FILENAME>" */%}}
 ```
 
 ### Examples
@@ -438,13 +438,13 @@ To use a local specification from the website `data/docs/openapi/` directory:
 Display the API information for a remote specification at `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json`:
 
 ```markdown
-{{/*% docs/openapi/info url="https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json" %*/}}
+{{%/* docs/openapi/info url="https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json" */%}}
 ```
 
 Display the API information for a local specification named `grafana`:
 
 ```markdown
-{{/*% docs/openapi/info data="grafana" %*/}}
+{{%/* docs/openapi/info data="grafana" */%}}
 ```
 
 ## Docs/openapi/path
@@ -465,16 +465,16 @@ Reference lookups function except for nested Response properties which require l
 
 Display all paths for the `grafana` data specification:
 
-```
-{{/*% docs/openapi/path data="grafana" %*/}}
+```markdown
+{{%/* docs/openapi/path data="grafana" */%}}
 or
-{{/*% docs/openapi/path data="grafana" scope="" %*/}}
+{{%/* docs/openapi/path data="grafana" scope="" */%}}
 ```
 
 Display only the `/teams` paths for the `grafana` data specification:
 
-```
-{{/*% docs/openapi/path data="grafana" scope="/teams" %*/}}
+```markdown
+{{%/* docs/openapi/path data="grafana" scope="/teams" */%}}
 ```
 
 ## Docs/play

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -412,6 +412,67 @@ This isn't rendered.
 
 This is rendered after the ignore.
 
+## Docs/openapi/info
+
+Display information about an OpenAPI 3.0+ specification, use either the `url` or `data` parameter to specify an OpenAPI specification.
+
+| Parameter | Description                              | Required |
+| --------- | ---------------------------------------- | -------- |
+| `url`     | The URL of the OpenAPI specification to fetch.   | no     |
+| `data`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no      |
+
+To fetch a remote specification from a URL:
+
+```markdown
+{{/*% docs/openapi/info url="<SPECIFICATION_URL>" %*/}}
+```
+
+To use a local specification from the website `data/docs/openapi/` directory:
+
+```markdown
+{{/*% docs/openapi/info data="<SPECIFICATION_FILENAME>" %*/}}
+```
+
+### Examples
+
+Display the API information for a remote specification at `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json`:
+
+```markdown
+{{/*% docs/openapi/info url="https://grafana.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json" %*/}}
+```
+
+Display the API information for a local specification named `grafana`:
+
+```markdown
+{{/*% docs/openapi/info data="grafana" %*/}}
+```
+
+## Docs/openapi/path
+
+Display API path information, use either the `url` or `data` parameter to specify an OpenAPI specification.
+
+| Parameter | Description                              | Required |
+| --------- | ---------------------------------------- | -------- |
+| `url`     | The URL of the OpenAPI specification to fetch.   | no     |
+| `title`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no      |
+| `scope`     | The API path to scope output to.   | no     |
+
+### Example
+
+Display all paths for the `grafana` data specification:
+
+```
+{{/*% docs/openapi/path data="grafana" %*/}}
+or
+{{/*% docs/openapi/path data="grafana" scope="" %*/}}
+```
+
+Display only the `/teams` paths for the `grafana` data specification:
+
+```
+{{/*% docs/openapi/path data="grafana" scope="/teams" %*/}}
+```
+
 ## Docs/play
 
 The `docs/play` shortcode produces a note admonition with the preferred copy for linking to a Grafana Play dashboard.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -438,7 +438,7 @@ To use a local specification from the website `data/docs/openapi/` directory:
 Display the API information for a remote specification at `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json`:
 
 ```markdown
-{{/*% docs/openapi/info url="https://grafana.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json" %*/}}
+{{/*% docs/openapi/info url="https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore-expanded.json" %*/}}
 ```
 
 Display the API information for a local specification named `grafana`:

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -457,6 +457,10 @@ Display API path information, use either the `url` or `data` parameter to specif
 | `title`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no      |
 | `scope`     | The API path to scope output to.   | no     |
 
+{{< admonition type="note" >}}
+Reference lookups function except for nested Response properties which require linking to an Object definition, probably embedded later in the page.
+{{< /admonition >}}
+
 ### Example
 
 Display all paths for the `grafana` data specification:

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -416,10 +416,10 @@ This is rendered after the ignore.
 
 Display information about an OpenAPI 3.0+ specification, use either the `url` or `data` parameter to specify an OpenAPI specification.
 
-| Parameter | Description                              | Required |
-| --------- | ---------------------------------------- | -------- |
-| `url`     | The URL of the OpenAPI specification to fetch.   | no     |
-| `data`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no      |
+| Parameter | Description                                                                                       | Required |
+| --------- | ------------------------------------------------------------------------------------------------- | -------- |
+| `url`     | The URL of the OpenAPI specification to fetch.                                                    | no       |
+| `data`    | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no       |
 
 To fetch a remote specification from a URL:
 
@@ -451,11 +451,11 @@ Display the API information for a local specification named `grafana`:
 
 Display API path information, use either the `url` or `data` parameter to specify an OpenAPI specification.
 
-| Parameter | Description                              | Required |
-| --------- | ---------------------------------------- | -------- |
-| `url`     | The URL of the OpenAPI specification to fetch.   | no     |
-| `title`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no      |
-| `scope`     | The API path to scope output to.   | no     |
+| Parameter | Description                                                                                       | Required |
+| --------- | ------------------------------------------------------------------------------------------------- | -------- |
+| `url`     | The URL of the OpenAPI specification to fetch.                                                    | no       |
+| `title`   | The filename of the OpenAPI specification to use from the website `data/docs/openapi/` directory. | no       |
+| `scope`   | The API path to scope output to.                                                                  | no       |
 
 {{< admonition type="note" >}}
 Reference lookups function except for nested Response properties which require linking to an Object definition, probably embedded later in the page.


### PR DESCRIPTION
Add documentation for the `docs/openapi/info` and `docs/openapi/path` shortcodes.