### PR TITLE
Publish documentation using the GitHub App

### DIFF
--- a/publish-technical-documentation/action.yml
+++ b/publish-technical-documentation/action.yml
@@ -27,19 +27,23 @@ runs:
     - id: get-secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@main
       with:
-        # sync-token and publish-token are fine-grained GitHub Personal Access Tokens that expire.
-        # They must be updated in the grafanabot GitHub account.
-        # A Vault admin can add them the ci/common/docs-team/website Vault path.
         common_secrets: |
-          WEBSITE_SYNC_TOKEN=docs-team/website:sync-token
-          PUBLISH_TO_WEBSITE_TOKEN=docs-team/website:publish-token
+          PUBLISH_TECHNICAL_DOCUMENTATION_APP_ID=docs-team/publish-technical-documentation:app-id
+          PUBLISH_TECHNICAL_DOCUMENTATION_PRIVATE_KEY=docs-team/publish-technical-documentation:key
+
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ env.PUBLISH_TECHNICAL_DOCUMENTATION_APP_ID }}
+        owner: grafana
+        private-key: ${{ env.PUBLISH_TECHNICAL_DOCUMENTATION_PRIVATE_KEY }}
 
     - name: Checkout sync action
       uses: actions/checkout@v4
       with:
         path: .github/actions/website-sync
         repository: grafana/website-sync
-        token: ${{ env.WEBSITE_SYNC_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Sync to the website repository
       uses: ./.github/actions/website-sync
@@ -48,6 +52,6 @@ runs:
         repository: grafana/website
         branch: master
         host: github.com
-        github_pat: grafanabot:${{ env.PUBLISH_TO_WEBSITE_TOKEN }}
+        github_pat: grafanabot:${{ steps.app-token.outputs.token }}
         source_folder: ${{ inputs.source_directory }}
         target_folder: ${{ inputs.website_directory }}


### PR DESCRIPTION
It has limited installation so that it can only clone the repositories it needs:

- grafana/website-sync
- grafana/website

Tested in https://github.com/grafana/writers-toolkit/commit/82b7a14a102e5e19f4d2a023b9248a2400bab60d and https://github.com/grafana/writers-toolkit/actions/runs/10899782533/job/30245958284#step:3:622 which resulted in a 404 when trying to check out grafana/technical-documentation.

You can use the default GITHUB_TOKEN to check out the source repository.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

