### PR TITLE
Remove broken link

### DIFF
--- a/docs/sources/write/grot-guides/index.md
+++ b/docs/sources/write/grot-guides/index.md
@@ -12,7 +12,7 @@ weight: 501
 
 Grot guides are interactive guides embedded in a documentation page that people can follow to get help and guidance on topics and direction to documentation resources.
 
-The [`guide` shortcode](/docs/writers-toolkit/write-shortcodes/#guide) embeds a Grot guide into a page.
+The `guide` shortcode embeds a Grot guide into a page.
 
 ```markdown
 {{</* guide name="<NAME>" title="<TITLE>" text="<TEXT>" button="<BUTTON>" */>}}


### PR DESCRIPTION
The link was wrong in the first place and there is not a `guide` shortcode reference on https://grafana.com/docs/writers-toolkit/write/shortcodes/, only https://grafana.com/docs/writers-toolkit/write/shortcodes/#grot-guides which links back to this page.