### PR TITLE
chore: Pin `send-slack-message` workflow

### DIFF
--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Send Slack Message
         id: slack
         if: ${{ steps.add-to-docs-project.outputs.added != ''}}
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
         with:
           channel-id: C05V6A36MB7
           payload: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Notify failure
         if: failure()
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
         with:
           channel-id: C05V6A36MB7
           payload: |


### PR DESCRIPTION
### Summary of changes

**Why is the change needed, what does it improve?**

`send-slack-message` upstream action has a lot of breaking changes ([see here](https://github.com/grafana/shared-workflows/pull/534)). We need to make sure that all usages of our shared-workflow are pinned to avoid breakages.
