### PR TITLE
use custom _index.md for deploy previews

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -20,4 +20,4 @@ jobs:
       repo: writers-toolkit
       website_directory: content/docs/writers-toolkit
       relative_prefix: /docs/writers-toolkit/
-      index_file: false
+      index_file: true

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@robbymilo/deploy-preview
     with:
       sha: ${{ github.event.pull_request.head.sha }}
       branch: ${{ github.head_ref }}
@@ -20,3 +20,4 @@ jobs:
       repo: writers-toolkit
       website_directory: content/docs/writers-toolkit
       relative_prefix: /docs/writers-toolkit/
+      index_file: false

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -20,4 +20,4 @@ jobs:
       repo: writers-toolkit
       website_directory: content/docs/writers-toolkit
       relative_prefix: /docs/writers-toolkit/
-      index_file: true
+      index_file: false

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@robbymilo/deploy-preview
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       sha: ${{ github.event.pull_request.head.sha }}
       branch: ${{ github.head_ref }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -112,7 +112,7 @@ jobs:
             -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" \
             --rm grafana/docs-base:latest \
             /bin/bash \
-              -c '${{ steps.create-index.outputs.create_index_command }}"HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+              -c '${{ steps.create-index.outputs.create_index_command }}HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,6 +27,9 @@ on:
       relative_prefix:
         required: true
         type: string
+      index_file: # creates the necessary project _index.md file for versioned repos
+        required: true
+        type: string
 
 env:
   CLOUD_RUN_REGION: us-south1
@@ -92,12 +95,29 @@ jobs:
           ls -al
           ls -al ${{ inputs.source_directory }}
 
+      - name: Create _index file
+        id: create-index
+        if: inputs.index_file == true
+        shell: bash
+        run: |
+          create_index_command=$(echo -e "---\\nredirectURL: \"/docs/${{ inputs.repo }}/latest\"\\ntype: redirect\\nversioned: true\\n---\\n" > "content/docs/${{ inputs.repo }}/_index.md" &&)
+          echo "create_index_command=$create_index_command" >> $GITHUB_OUTPUT
+
       - name: Build website
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         run: |
-          mkdir -p ${PWD}/dist
-          docker run -v ${PWD}/dist:/hugo/dist -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" --rm grafana/docs-base:latest /bin/bash -c 'echo -e "---\\nredirectURL: \"/docs/grafana/latest\"\\ntype: redirect\\nversioned: true\\n---\\n" > "content/docs/grafana/_index.md" && HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+          docker run \
+            -v "${PWD}/dist:/hugo/dist" \
+            -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" \
+            --rm grafana/docs-base:latest \
+            /bin/bash \
+              -c '${{ steps.create-index.outputs.create_index_command }}"HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+
+      - name: Print build header value
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        shell: bash
+        run: |
           printf "%s" "add_header 'Build' '"${{ inputs.sha }}"';" > build.conf
 
       - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -102,7 +102,8 @@ jobs:
         env:
           source_directory: ${{ inputs.source_directory }}
           website_directory: ${{ inputs.website_directory }}
-          index_file: ${{ inputs. index_file }}
+          index_file: ${{ inputs.index_file }}
+          repo: ${{ inputs.repo }}
         run: |
           ./deploy-preview-files/deploy-preview/build.sh
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -100,7 +100,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         run: |
-          ./deploy-preview-files/build.sh
+          ./deploy-preview-files/deploy-preview/build.sh
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -100,10 +100,10 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         env:
-          source_directory: ${{ inputs.source_directory }}
-          website_directory: ${{ inputs.website_directory }}
-          index_file: ${{ inputs.index_file }}
-          repo: ${{ inputs.repo }}
+          SOURCE_DIRECTORY: ${{ inputs.source_directory }}
+          WEBSITE_DIRECTORY: ${{ inputs.website_directory }}
+          INDEX_FILE: ${{ inputs.index_file }}
+          REPO: ${{ inputs.repo }}
         run: |
           ./deploy-preview-files/deploy-preview/build.sh
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -94,6 +94,7 @@ jobs:
           rm -rf !(docs|deploy-preview-files|.git)
           ls -al
           ls -al ${{ inputs.source_directory }}
+          ls -al deploy-preview-files
 
       - name: Build website
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -100,7 +100,7 @@ jobs:
         if: inputs.index_file == true
         shell: bash
         run: |
-          create_index_command=$(echo -e "---\\nredirectURL: \"/docs/${{ inputs.repo }}/latest\"\\ntype: redirect\\nversioned: true\\n---\\n" > "content/docs/${{ inputs.repo }}/_index.md" &&)
+          create_index_command=$("echo -e '---\\nredirectURL:\\s\/docs/${{ inputs.repo }}/latest/\\ntype:\\sredirect\\nversioned:\\strue\\n---\\n' > content/docs/${{ inputs.repo }}/_index.md &&")
           echo "create_index_command=$create_index_command" >> $GITHUB_OUTPUT
 
       - name: Build website

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,7 +29,7 @@ on:
         type: string
       index_file: # creates the necessary project _index.md file for versioned repos
         required: true
-        type: string
+        type: boolean
 
 env:
   CLOUD_RUN_REGION: us-south1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         run: |
-          ./deploy-preview/build.sh
+          ./deploy-preview-files/build.sh
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -79,7 +79,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: "main"
+          ref: "robbymilo/deploy-preview"
           path: deploy-preview-files
           sparse-checkout: |
             deploy-preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -95,24 +95,11 @@ jobs:
           ls -al
           ls -al ${{ inputs.source_directory }}
 
-      - name: Create _index file
-        id: create-index
-        if: inputs.index_file == true
-        shell: bash
-        run: |
-          create_index_command=$("echo -e '---\\nredirectURL:\\s\/docs/${{ inputs.repo }}/latest/\\ntype:\\sredirect\\nversioned:\\strue\\n---\\n' > content/docs/${{ inputs.repo }}/_index.md &&")
-          echo "create_index_command=$create_index_command" >> $GITHUB_OUTPUT
-
       - name: Build website
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         run: |
-          docker run \
-            -v "${PWD}/dist:/hugo/dist" \
-            -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" \
-            --rm grafana/docs-base:latest \
-            /bin/bash \
-              -c '${{ steps.create-index.outputs.create_index_command }}HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+          ./deploy-preview/build.sh
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -99,6 +99,10 @@ jobs:
       - name: Build website
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
+        env:
+          source_directory: ${{ inputs.source_directory }}
+          website_directory: ${{ inputs.website_directory }}
+          index_file: ${{ inputs. index_file }}
         run: |
           ./deploy-preview-files/deploy-preview/build.sh
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -97,7 +97,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ${PWD}/dist
-          docker run -v ${PWD}/dist:/hugo/dist -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" --rm grafana/docs-base:latest /bin/bash -c 'HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+          docker run -v ${PWD}/dist:/hugo/dist -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" --rm grafana/docs-base:latest /bin/bash -c 'echo -e "---\\nredirectURL: \"/docs/grafana/latest\"\\ntype: redirect\\nversioned: true\\n---\\n" > "content/docs/grafana/_index.md" && HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
           printf "%s" "add_header 'Build' '"${{ inputs.sha }}"';" > build.conf
 
       - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -79,7 +79,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: "robbymilo/deploy-preview"
+          ref: "main"
           path: deploy-preview-files
           sparse-checkout: |
             deploy-preview

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /add-to-docs-project/node_modules/
 /add-to-docs-project/index.mjs
 build.conf
+/dist

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -2,7 +2,7 @@
 
 docker run \
   -v "${PWD}/dist:/hugo/dist" \
-  -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" \
+  -v "${PWD}/${source_directory}:/hugo/${website_directory}" \
   --rm grafana/docs-base:latest \
   /bin/bash \
     -c 'HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -2,7 +2,7 @@
 
 docker run \
   -v "${PWD}/dist:/hugo/dist" \
-  -v "${PWD}/${source_directory}:/hugo/${website_directory}" \
+  -v "${source_directory}:/hugo/${website_directory}" \
   -e index_file \
   -e repo \
   -e website_directory \
@@ -10,13 +10,15 @@ docker run \
   /bin/bash \
     -c '
 if [[ "${index_file}" == "true" ]]; then
-  mkdir -p "/hugo/${website_directory}/content/docs/${repo}" && \
-  cat > "/hugo/${website_directory}/content/docs/${repo}/_index.md" <<EOF
+  echo "Creating custom _index.md" && \
+  cat > "/hugo/content/docs/${repo}/_index.md" <<EOF
+---
 type: redirect
 redirectURL: /docs/${repo}/latest/
 versioned: true
+---
 EOF
 fi
-cat "/hugo/${website_directory}/content/docs/${repo}/_index.md"
+cat "/hugo/content/docs/${repo}/_index.md"
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
 '

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -2,7 +2,7 @@
 
 docker run \
   -v "${PWD}/dist:/hugo/dist" \
-  -v "${source_directory}:/hugo/${website_directory}" \
+  -v "${PWD}/${source_directory}:/hugo/${website_directory}" \
   -e index_file \
   -e repo \
   -e website_directory \

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+docker run \
+  -v "${PWD}/dist:/hugo/dist" \
+  -v "${PWD}/${{ inputs.source_directory }}:/hugo/${{ inputs.website_directory }}" \
+  --rm grafana/docs-base:latest \
+  /bin/bash \
+    -c 'HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -3,6 +3,20 @@
 docker run \
   -v "${PWD}/dist:/hugo/dist" \
   -v "${PWD}/${source_directory}:/hugo/${website_directory}" \
+  -e index_file \
+  -e repo \
+  -e website_directory \
   --rm grafana/docs-base:latest \
   /bin/bash \
-    -c 'HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify'
+    -c '
+if [[ "${index_file}" == "true" ]]; then
+  mkdir -p "/hugo/${website_directory}/content/docs/${repo}" && \
+  cat > "/hugo/${website_directory}/content/docs/${repo}/_index.md" <<EOF
+type: redirect
+redirectURL: /docs/${repo}/latest/
+versioned: true
+EOF
+fi
+cat "/hugo/${website_directory}/content/docs/${repo}/_index.md"
+HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
+'

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -2,23 +2,23 @@
 
 docker run \
   -v "${PWD}/dist:/hugo/dist" \
-  -v "${PWD}/${source_directory}:/hugo/${website_directory}" \
-  -e index_file \
-  -e repo \
-  -e website_directory \
+  -v "${PWD}/${SOURCE_DIRECTORY}:/hugo/${WEBSITE_DIRECTORY}" \
+  -e INDEX_FILE \
+  -e REPO \
+  -e WEBSITE_DIRECTORY \
   --rm grafana/docs-base:latest \
   /bin/bash \
     -c '
-if [[ "${index_file}" == "true" ]]; then
+if [[ "${INDEX_FILE}" == "true" ]]; then
   echo "Creating custom _index.md" && \
-  cat > "/hugo/content/docs/${repo}/_index.md" <<EOF
+  cat > "/hugo/content/docs/${REPO}/_index.md" <<EOF
 ---
 type: redirect
-redirectURL: /docs/${repo}/latest/
+redirectURL: /docs/${REPO}/latest/
 versioned: true
 ---
 EOF
 fi
-cat "/hugo/content/docs/${repo}/_index.md"
+cat "/hugo/content/docs/${REPO}/_index.md"
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
 '

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -7,7 +7,7 @@ cascade:
     products:
       - oss
   public_docs: true
-  replace_dir: docs/writers-toolkit/
+  replace_dir: "docs/writers-toolkit/"
   search_section: Writers' Toolkit
   search_type: doc
 date: "2022-06-23T11:09:48+01:00"

--- a/home/robbymilo/grafana/grafana/docs/sources/content/docs/grafana/_index.md
+++ b/home/robbymilo/grafana/grafana/docs/sources/content/docs/grafana/_index.md
@@ -1,3 +1,0 @@
-type: redirect
-redirectURL: /docs/grafana/latest/
-versioned: true

--- a/home/robbymilo/grafana/grafana/docs/sources/content/docs/grafana/_index.md
+++ b/home/robbymilo/grafana/grafana/docs/sources/content/docs/grafana/_index.md
@@ -1,0 +1,3 @@
+type: redirect
+redirectURL: /docs/grafana/latest/
+versioned: true


### PR DESCRIPTION
for https://github.com/grafana/website/issues/10101

This PR fixes the shared content shortcodes in deploy previews by adding the `index_file` input param, and if true creates a custom `_index.md` file similar to the `make docs` command.

See https://github.com/grafana/grafana/pull/97355 for the fixed run.

Todo:
- [x] change refs back to main