### PR TITLE
Default to allowing no changes during sync

### DIFF
--- a/publish-technical-documentation/action.yml
+++ b/publish-technical-documentation/action.yml
@@ -49,6 +49,7 @@ runs:
       uses: ./.github/actions/website-sync
       id: publish
       with:
+        allow_no_changes: true
         repository: grafana/website
         branch: master
         host: github.com


### PR DESCRIPTION
This isn't often a failure case and causes a lot of noise for repositories with multiple documentation projects