### PR TITLE
Add workflow to test publish-technical-documentation-release workflow

### DIFF
--- a/.github/workflows/test-publish-technical-documentation-release.yml
+++ b/.github/workflows/test-publish-technical-documentation-release.yml
@@ -3,7 +3,7 @@ name: test-publish-technical-documentation-release
 on:
   push:
     branches:
-      - test/publish-technical-documentation-release/v[0-9]+.[0-9]+.[0-9]+
+      - test/publish-technical-documentation-release/v[0-9]+.[0-9]+.x
     tags:
       - test/publish-technical-documentation-release/v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:

--- a/.github/workflows/test-publish-technical-documentation-release.yml
+++ b/.github/workflows/test-publish-technical-documentation-release.yml
@@ -1,0 +1,28 @@
+name: test-publish-technical-documentation-release
+
+on:
+  push:
+    branches:
+      - test/publish-technical-documentation-release/v[0-9]+.[0-9]+.[0-9]+
+    tags:
+      - test/publish-technical-documentation-release/v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
+jobs:
+  sync:
+    if: github.repository == 'grafana/writers-toolkit'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./publish-technical-documentation-release
+        with:
+          release_tag_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_branch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
+          release_branch_with_patch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          website_branch: test/publish-technical-documentation-release
+          website_directory: content/docs/publish-technical-documetation-release
+          version_suffix: ""

--- a/.github/workflows/test-publish-technical-documentation-release.yml
+++ b/.github/workflows/test-publish-technical-documentation-release.yml
@@ -1,3 +1,10 @@
+# To use this workflow to test the publish-technical-documentation-release action:
+#   1. Create a branch `test/publish-technical-documentation/v<MAJOR>.<MINOR>.x`.
+#   2. Iterate on the workflow or action.
+#   3a. To test push events, push the branch.
+#   3b. To test tag events, tag the branch with `test/publish-technical-documentation/v<MAJOR>.<MINOR>.<PATCH>`.
+#   4. Check the workflow output in https://github.com/grafana/writers-toolkit/actions.
+
 name: test-publish-technical-documentation-release
 
 on:

--- a/.github/workflows/test-publish-technical-documentation-release.yml
+++ b/.github/workflows/test-publish-technical-documentation-release.yml
@@ -20,9 +20,9 @@ jobs:
           fetch-depth: 0
       - uses: ./publish-technical-documentation-release
         with:
-          release_tag_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
-          release_branch_with_patch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_tag_regexp: "^test/publish-technical-documentation-release/v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.x$"
+          release_branch_with_patch_regexp: "^test/publish-technical-documentation-release/v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           website_branch: test/publish-technical-documentation-release
           website_directory: content/docs/publish-technical-documetation-release
           version_suffix: ""

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -58,6 +58,25 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Switch to HEAD of branch for tags
+      # Tags aren't necessarily made to the HEAD of the branch.
+      # The documentation to be published is always on the HEAD of the branch.
+      if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
+      env:
+        GITHUB_REF: ${{ github.ref }}
+        RELEASE_BRANCH_REGEXP: ${{ inputs.release_branch_regexp }}
+      run: |
+        branch="$(./publish-technical-documentation-release/determine-release-branch "${RELEASE_BRANCH_REGEXP}" "${GITHUB_REF}")"
+
+        if [[ -z "${branch}" ]]; then
+          echo "No release branch found for tag ${GITHUB_REF} matching ${RELEASE_BRANCH_REGEXP}. Exiting."
+
+          exit 1
+        fi
+
+        git switch --detach "origin/${branch}"
+      shell: bash
+
     - name: Build website
       shell: bash
       run: |
@@ -105,25 +124,6 @@ runs:
       id: target
       with:
         ref_name: ${{ github.ref_name }}
-
-    - name: Switch to HEAD of version branch for tags
-      # Tags aren't necessarily made to the HEAD of the version branch.
-      # The documentation to be published is always on the HEAD of the release branch.
-      if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
-      env:
-        GITHUB_REF: ${{ github.ref }}
-        RELEASE_BRANCH_REGEXP: ${{ inputs.release_branch_regexp }}
-      run: |
-        branch="$(./publish-technical-documentation-release/determine-release-branch "${RELEASE_BRANCH_REGEXP}" "${GITHUB_REF}")"
-
-        if [[ -z "${branch}" ]]; then
-          echo "No release branch found for tag ${GITHUB_REF} matching ${RELEASE_BRANCH_REGEXP}. Exiting."
-
-          exit 1
-        fi
-
-        git switch --detach "origin/${branch}"
-      shell: bash
 
     - name: Sync to the website repository (release)
       if: steps.has-matching-release-tag.outputs.bool == 'true'

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -61,7 +61,7 @@ runs:
     - name: Switch to HEAD of branch for tags
       # Tags aren't necessarily made to the HEAD of the branch.
       # The documentation to be published is always on the HEAD of the branch.
-      if: steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'
+      if: github.ref_type == 'tag'
       env:
         GITHUB_REF: ${{ github.ref }}
         RELEASE_BRANCH_REGEXP: ${{ inputs.release_branch_regexp }}
@@ -108,15 +108,6 @@ runs:
     - name: Install Actions from library
       run: npm install --production --prefix ./actions
       shell: bash
-
-    - name: Determine if there is a matching release tag
-      id: has-matching-release-tag
-      uses: ./actions/has-matching-release-tag
-      with:
-        ref_name: ${{ github.ref_name }}
-        release_branch_regexp: ${{ inputs.release_branch_regexp }}
-        release_branch_with_patch_regexp: ${{ inputs.release_branch_with_patch_regexp }}
-        release_tag_regexp: ${{ inputs.release_tag_regexp }}
 
     - name: Determine technical documentation version
       if: steps.has-matching-release-tag.outputs.bool == 'true'

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -41,6 +41,10 @@ inputs:
   source_directory:
     default: docs/sources
     description: Path to source directory, relative to the project root, to sync documentation from.
+  website_branch:
+    default: master
+    description: |
+      Website repository branch to sync the documentation to.
   website_directory:
     description: |
       Website directory to sync the documentation to.
@@ -127,7 +131,7 @@ runs:
       id: publish-release
       with:
         repository: grafana/website
-        branch: master
+        branch: ${{ inputs.website_branch }}
         host: github.com
         github_pat: grafanabot:${{ env.PUBLISH_TO_WEBSITE_TOKEN }}
         source_folder: ${{ inputs.source_directory }}

--- a/publish-technical-documentation-release/determine-release-branch
+++ b/publish-technical-documentation-release/determine-release-branch
@@ -23,7 +23,8 @@ fi
 BRANCH_REGEXP="$1"
 TAG="${2#refs/tags/}"
 
-for branch in $(git branch -a --contains "tags/${TAG}"); do
+contains="$(git branch -a --contains "tags/${TAG}")"
+for branch in ${contains}; do
   branch="${branch#remotes/origin/}";
 
   if [[ "${branch}" =~ ${BRANCH_REGEXP} ]]; then
@@ -33,4 +34,7 @@ for branch in $(git branch -a --contains "tags/${TAG}"); do
   fi;
 done
 
+echo "No release branch found for tag ${TAG} matching ${BRANCH_REGEXP}. Exiting." >&2
+echo "Branches containing tag ${TAG}:" >&2
+echo "${contains}" >&2
 exit 1

--- a/publish-technical-documentation-release/determine-release-branch
+++ b/publish-technical-documentation-release/determine-release-branch
@@ -26,6 +26,7 @@ TAG="${2#refs/tags/}"
 contains="$(git branch -a --contains "tags/${TAG}")"
 for branch in ${contains}; do
   branch="${branch#remotes/origin/}";
+  echo "Checking branch ${branch} against ${BRANCH_REGEXP}." >&2
 
   if [[ "${branch}" =~ ${BRANCH_REGEXP} ]]; then
     echo "${branch}";

--- a/publish-technical-documentation-release/determine-release-branch
+++ b/publish-technical-documentation-release/determine-release-branch
@@ -21,7 +21,7 @@ if [[ $# -ne 2 ]]; then
 fi
 
 BRANCH_REGEXP="$1"
-TAG="$2"
+TAG="${2#refs/tags/}"
 
 for branch in $(git branch -a --contains "tags/${TAG}"); do
   branch="${branch#remotes/origin/}";


### PR DESCRIPTION
Makes it possible to develop and test this workflow in this repository so you don't have to publish the workflow and then test it somewhere else.

The dev/test workflow now looks like:

1. Create a branch `test/publish-technical-documentation/v<MAJOR>.<MINOR>.x`.
1. Iterate on the workflow or action.
1. To test push events, push the branch
1. To test tag events, tag the branch with `test/publish-technical-documentation/v<MAJOR>.<MINOR>.<PATCH>`
1. Check the workflow output in https://github.com/grafana/writers-toolkit/actions

I've added rulesets for the new branches and tags:
- https://github.com/grafana/writers-toolkit/settings/rules/2899360
- https://github.com/grafana/writers-toolkit/settings/rules/2899365

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>