### PR TITLE
Restore missing has-matching-release-tag step

### DIFF
--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -109,6 +109,15 @@ runs:
       run: npm install --production --prefix ./actions
       shell: bash
 
+    - name: Determine if there is a matching release tag
+      id: has-matching-release-tag
+      uses: ./actions/has-matching-release-tag
+      with:
+        ref_name: ${{ github.ref_name }}
+        release_branch_regexp: ${{ inputs.release_branch_regexp }}
+        release_branch_with_patch_regexp: ${{ inputs.release_branch_with_patch_regexp }}
+        release_tag_regexp: ${{ inputs.release_tag_regexp }}
+
     - name: Determine technical documentation version
       if: steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./actions/docs-target


### PR DESCRIPTION
I managed to remove this step when I was moving bits around in #917.

Tested in https://github.com/grafana/grafana/actions/runs/12412933836/job/34653905262.

- [x] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
