### PR TITLE
Replace individual inputs with JSON string array of inputs

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - "docs/sources/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.repo }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-pr-preview:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -20,15 +24,7 @@ jobs:
           sparse-checkout-cone-mode: false # exclude root files
           sparse-checkout: docs
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-          repo: grafana/writers-toolkit
-          sparse-checkout-cone-mode: false # exclude root files
-          sparse-checkout: |
-            .github/workflows/deploy-preview.yml
-
-      - uses: ./.github/workflows/deploy-preview.yml
+      - uses: ./deploy-preview
         with:
           branch: ${{ github.head_ref }}
           event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,14 +11,17 @@ on:
 
 jobs:
   deploy-pr-preview:
-    if: ! github.event.pull_request.head.repo.fork
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/2025-01-multiple-source-deploy-preview
     with:
-      sha: ${{ github.event.pull_request.head.sha }}
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      sources: |
+        [{
+            "index_file": null,
+            "relative_prefix": "/docs/writers-toolkit/",
+            "source_directory": "docs/sources",
+            "website_directory": "content/docs/writers-toolkit"
+        }]
       title: ${{ github.event.pull_request.title }}
-      repo: writers-toolkit
-      website_directory: content/docs/writers-toolkit
-      relative_prefix: /docs/writers-toolkit/
-      index_file: false

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,22 +12,32 @@ on:
 jobs:
   deploy-pr-preview:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        sparse-checkout-cone-mode: false # exclude root files
-        sparse-checkout: docs
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false # exclude root files
+          sparse-checkout: docs
 
-    - uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/2025-01-multiple-source-deploy-preview
-      with:
-        branch: ${{ github.head_ref }}
-        event_number: ${{ github.event.number }}
-        sha: ${{ github.event.pull_request.head.sha }}
-        sources: |
-          [{
-              "index_file": null,
-              "relative_prefix": "/docs/writers-toolkit/",
-              "source_directory": "docs/sources",
-              "website_directory": "content/docs/writers-toolkit"
-          }]
-        title: ${{ github.event.pull_request.title }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          repo: grafana/writers-toolkit
+          sparse-checkout-cone-mode: false # exclude root files
+          sparse-checkout: |
+            .github/workflows/deploy-preview.yml
+
+      - uses: ./.github/workflows/deploy-preview.yml
+        with:
+          branch: ${{ github.head_ref }}
+          event_number: ${{ github.event.number }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          sources: |
+            [{
+                "index_file": null,
+                "relative_prefix": "/docs/writers-toolkit/",
+                "source_directory": "docs/sources",
+                "website_directory": "content/docs/writers-toolkit"
+            }]
+          title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,16 +12,22 @@ on:
 jobs:
   deploy-pr-preview:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/2025-01-multiple-source-deploy-preview
-    with:
-      branch: ${{ github.head_ref }}
-      event_number: ${{ github.event.number }}
-      sha: ${{ github.event.pull_request.head.sha }}
-      sources: |
-        [{
-            "index_file": null,
-            "relative_prefix": "/docs/writers-toolkit/",
-            "source_directory": "docs/sources",
-            "website_directory": "content/docs/writers-toolkit"
-        }]
-      title: ${{ github.event.pull_request.title }}
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        sparse-checkout-cone-mode: false # exclude root files
+        sparse-checkout: docs
+
+    - uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/2025-01-multiple-source-deploy-preview
+      with:
+        branch: ${{ github.head_ref }}
+        event_number: ${{ github.event.number }}
+        sha: ${{ github.event.pull_request.head.sha }}
+        sources: |
+          [{
+              "index_file": null,
+              "relative_prefix": "/docs/writers-toolkit/",
+              "source_directory": "docs/sources",
+              "website_directory": "content/docs/writers-toolkit"
+          }]
+        title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          sparse-checkout-cone-mode: false # exclude root files
-          sparse-checkout: docs
 
       - uses: ./deploy-preview
         with:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -16,6 +16,11 @@ concurrency:
 jobs:
   deploy-pr-preview:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      id-token: write # Fetch Vault secrets.
+      pull-requests: write # Create or update PR comments.
+      statuses: write # Update GitHub status check with deploy preview link.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,6 +3,54 @@ name: deploy-preview
 on:
   workflow_call:
     inputs:
+      sources:
+        description: |
+          sources is a JSON string describing multiple source mounts.
+
+          It replaces the individual inputs used in the previous version of this action.
+
+          The structure is an array of objects, each with the following keys:
+
+          index_file:
+            description: Path to index file used to redirect versioned projects. For example, "content/docs/mimir/_index.md".
+            required: true
+            type: string
+          relative_prefix:
+            description: The URL path prefix for the mount destination. For example, "/docs/mimir/latest/".
+            required: true
+            type: string
+          repo:
+            description: The Grafana repository name for the source files. For example, "mimir".
+            required: true
+            type: string
+          source_directory:
+            description: The path to the source files in the repository. For example, "docs/sources".
+            required: true
+            type: string
+          website_directory:
+            description: The path to mount the documentation in the website content structure. For example, "content/docs/mimir/latest".
+            required: true
+            type: string
+
+          The following example mounts both the Mimir documentation and the mimir-distributed Helm chart documentation:
+
+          [
+            {
+              "index_file": true,
+              "relative_prefix": "/docs/mimir/latest/",
+              "repo": "mimir",
+              "source_directory": "docs/sources/mimir",
+              "website_directory": "content/docs/mimir/latest"
+            },
+            {
+              "index_file": true,
+              "relative_prefix": "/docs/helm-charts/mimir-distributed/latest/",
+              "repo": "mimir",
+              "source_directory": "docs/sources/mimir-distributed",
+              "website_directory": "content/docs/helm-charts/mimir-distributed/latest"
+            }
+          ]
+        type: string
       sha:
         required: true
         type: string
@@ -16,19 +64,20 @@ on:
         required: true
         type: string
       repo:
-        required: true
+        deprecationMessage: Use the sources JSON string input instead.
         type: string
       source_directory:
+        deprecationMessage: Use the sources JSON string input instead.
         default: docs/sources
         type: string
       website_directory:
-        required: true
+        deprecationMessage: Use the sources JSON string input instead.
         type: string
       relative_prefix:
-        required: true
+        deprecationMessage: Use the sources JSON string input instead.
         type: string
-      index_file: # creates the necessary project _index.md file for versioned repos
-        required: true
+      index_file:
+        deprecationMessage: Use the sources JSON string input instead.
         type: boolean
 
 env:
@@ -67,13 +116,6 @@ jobs:
           body: |
             :building_construction: Updating deploy preview...
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
-        with:
-          sparse-checkout-cone-mode: false # exclude root files
-          sparse-checkout: docs
-
-      # get the Dockerfile and nginx conf
       - name: Sparse checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -105,7 +105,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: "main"
+          ref: jdb/2025-01-multiple-source-deploy-preview
           path: deploy-preview-files
           sparse-checkout: |
             deploy-preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -63,22 +63,6 @@ on:
       title:
         required: true
         type: string
-      repo:
-        deprecationMessage: Use the sources JSON string input instead.
-        type: string
-      source_directory:
-        deprecationMessage: Use the sources JSON string input instead.
-        default: docs/sources
-        type: string
-      website_directory:
-        deprecationMessage: Use the sources JSON string input instead.
-        type: string
-      relative_prefix:
-        deprecationMessage: Use the sources JSON string input instead.
-        type: string
-      index_file:
-        deprecationMessage: Use the sources JSON string input instead.
-        type: boolean
 
 env:
   CLOUD_RUN_REGION: us-south1

--- a/deploy-preview/Dockerfile
+++ b/deploy-preview/Dockerfile
@@ -1,11 +1,13 @@
 FROM nginx:1.21.6-alpine
-
-COPY ./dist /usr/share/nginx/dist
+ARG ACTION_PATH
+ENV ACTION_PATH="${ACTION_PATH:-deploy-preview-files/deploy-preview/}"
 
 RUN rm -rf /etc/nginx/sites-enabled && \
   rm -rf /etc/nginx/nginx.conf
 
-COPY deploy-preview-files/deploy-preview/nginx.conf /etc/nginx/nginx.conf
+COPY "${ACTION_PATH}/deploy-preview-files/deploy-preview/nginx.conf" /etc/nginx/nginx.conf
 COPY build.conf /etc/nginx/build.conf
+
+COPY ./dist /usr/share/nginx/dist
 
 RUN nginx -t

--- a/deploy-preview/action.yml
+++ b/deploy-preview/action.yml
@@ -87,7 +87,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         SOURCES: ${{ inputs.sources }}
       run: |
-        "${ACTION_PATH}/deploy-preview-files/deploy-preview/build.sh"
+        "${ACTION_PATH}/build.sh"
       shell: bash
 
     - name: Print build header value
@@ -137,10 +137,11 @@ runs:
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
       id: build
       with:
-        context: .
+        build-args: |
+          ACTION_PATH=${{ github.action_path }}
+        file: ${{ github.action_path }}/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}
-        file: ./deploy-preview-files/deploy-preview/Dockerfile
 
     - uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
       id: gcloud-auth-cloud-run

--- a/deploy-preview/action.yml
+++ b/deploy-preview/action.yml
@@ -98,14 +98,14 @@ runs:
         printf "%s" "add_header 'Build' '"${SHA}"';" > build.conf
       shell: bash
 
-    - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
-      if: github.event.action == 'opened' || github.event.action == 'synchronize'
-      id: gcloud-auth
-      with:
-        token_format: access_token
-        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: github-docs-deploy-previews@grafanalabs-workload-identity.iam.gserviceaccount.com
-        create_credentials_file: false
+    # - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
+    #   if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    #   id: gcloud-auth
+    #   with:
+    #     token_format: access_token
+    #     workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+    #     service_account: github-docs-deploy-previews@grafanalabs-workload-identity.iam.gserviceaccount.com
+    #     create_credentials_file: false
 
     # - name: Login to GAR
     #   if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/deploy-preview/action.yml
+++ b/deploy-preview/action.yml
@@ -61,12 +61,6 @@ inputs:
 
 runs:
   using: composite
-  permissions:
-    contents: read
-    id-token: write # Fetch Vault secrets.
-    pull-requests: write # Create or update PR comments.
-    statuses: write # Update GitHub status check with deploy preview link.
-  runs-on: ubuntu-latest
   steps:
     - name: Find comment
       uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
@@ -89,20 +83,20 @@ runs:
 
     - name: Build website
       if: github.event.action == 'opened' || github.event.action == 'synchronize'
-      shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
         SOURCES: ${{ inputs.sources }}
       run: |
         "${ACTION_PATH}/deploy-preview-files/deploy-preview/build.sh"
+      shell: bash
 
     - name: Print build header value
       if: github.event.action == 'opened' || github.event.action == 'synchronize'
-      shell: bash
       env:
         SHA: ${{ inputs.sha }}
       run: |
         printf "%s" "add_header 'Build' '"${SHA}"';" > build.conf
+      shell: bash
 
     - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -183,6 +177,7 @@ runs:
         else
           echo "Service $SERVICE_NAME does not exist. Skipping step."
         fi
+      shell: bash
 
     - name: Send commit status
       uses: ouzi-dev/commit-status-updater@26588d166ff273fc4c0664517359948f7cdc9bf1 # v2.0.2

--- a/deploy-preview/action.yml
+++ b/deploy-preview/action.yml
@@ -107,13 +107,13 @@ runs:
         service_account: github-docs-deploy-previews@grafanalabs-workload-identity.iam.gserviceaccount.com
         create_credentials_file: false
 
-    - name: Login to GAR
-      if: github.event.action == 'opened' || github.event.action == 'synchronize'
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-      with:
-        registry: us-docker.pkg.dev
-        username: oauth2accesstoken
-        password: ${{ steps.gcloud-auth.outputs.access_token }}
+    # - name: Login to GAR
+    #   if: github.event.action == 'opened' || github.event.action == 'synchronize'
+    #   uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+    #   with:
+    #     registry: us-docker.pkg.dev
+    #     username: oauth2accesstoken
+    #     password: ${{ steps.gcloud-auth.outputs.access_token }}
 
     - name: Extract metadata (tags, labels) for Docker
       if: github.event.action == 'opened' || github.event.action == 'synchronize'

--- a/deploy-preview/action.yml
+++ b/deploy-preview/action.yml
@@ -1,0 +1,222 @@
+name: deploy-preview
+
+inputs:
+  sha:
+    required: true
+    type: string
+  branch:
+    required: true
+    type: string
+  event_number:
+    required: true
+    type: string
+  title:
+    required: true
+    type: string
+
+  sources:
+    description: |
+     sources is a JSON string describing multiple source mounts.
+     It replaces the individual inputs used in the previous version of this action.
+     The structure is an array of objects, each with the following keys:
+       index_file:
+          description: Path to index file used to redirect versioned projects. For example, "content/docs/mimir/_index.md".
+          required: true
+          type: string
+        relative_prefix:
+          description: The URL path prefix for the mount destination. For example, "/docs/mimir/latest/".
+          required: true
+          type: string
+        repo:
+          description: The Grafana repository name for the source files. For example, "mimir".
+          required: true
+          type: string
+        source_directory:
+          description: The path to the source files in the repository. For example, "docs/sources".
+          required: true
+          type: string
+        website_directory:
+          description: The path to mount the documentation in the website content structure. For example, "content/docs/mimir/latest".
+          required: true
+          type: string
+     The following example mounts both the Mimir documentation and the mimir-distributed Helm chart documentation:
+       [
+          {
+            "index_file": true,
+            "relative_prefix": "/docs/mimir/latest/",
+            "repo": "mimir",
+            "source_directory": "docs/sources/mimir",
+            "website_directory": "content/docs/mimir/latest"
+          },
+          {
+            "index_file": true,
+            "relative_prefix": "/docs/helm-charts/mimir-distributed/latest/",
+            "repo": "mimir",
+            "source_directory": "docs/sources/mimir-distributed",
+            "website_directory": "content/docs/helm-charts/mimir-distributed/latest"
+          }
+        ]
+    type: string
+
+
+runs:
+  using: composite
+  permissions:
+    contents: read
+    id-token: write # Fetch Vault secrets.
+    pull-requests: write # Create or update PR comments.
+    statuses: write # Update GitHub status check with deploy preview link.
+  runs-on: ubuntu-latest
+  steps:
+    - name: Find comment
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+      id: fc
+      with:
+        issue-number: ${{ inputs.event_number }}
+        comment-author: "github-actions[bot]"
+        body-includes: Deploy preview available
+
+    - name: Update comment with in-progress deploy preview
+      if: steps.fc.outputs.comment-id != '' && (github.event.action == 'opened' || github.event.action == 'synchronize')
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ inputs.event_number }}
+        edit-mode: append
+        append-separator: newline
+        body: |
+          :building_construction: Updating deploy preview...
+
+    - name: Build website
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        SOURCES: ${{ inputs.sources }}
+      run: |
+        "${ACTION_PATH}/deploy-preview-files/deploy-preview/build.sh"
+
+    - name: Print build header value
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      shell: bash
+      env:
+        SHA: ${{ inputs.sha }}
+      run: |
+        printf "%s" "add_header 'Build' '"${SHA}"';" > build.conf
+
+    - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      id: gcloud-auth
+      with:
+        token_format: access_token
+        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        service_account: github-docs-deploy-previews@grafanalabs-workload-identity.iam.gserviceaccount.com
+        create_credentials_file: false
+
+    - name: Login to GAR
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: us-docker.pkg.dev
+        username: oauth2accesstoken
+        password: ${{ steps.gcloud-auth.outputs.access_token }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      id: meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+      with:
+        images: "us-docker.pkg.dev/grafanalabs-dev/docker-docs-previews-dev/${{ inputs.repo }}"
+        tags: |-
+          "${{ inputs.sha }}"
+          "${{ inputs.event_number }}"
+
+    - name: Set up Docker Buildx
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+      with:
+        cache-binary: false
+        driver: docker-container
+
+    - name: Build the container
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+      id: build
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        file: ./deploy-preview-files/deploy-preview/Dockerfile
+
+    - uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+      id: gcloud-auth-cloud-run
+      with:
+        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        service_account: "github-docs-cloud-run-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
+
+    - name: Deploy to Cloud Run
+      uses: google-github-actions/deploy-cloudrun@1ec29da1351112c7904fb60454a55e3e1021a51c # v2.7.2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      id: deploy
+      with:
+        image: us-docker.pkg.dev/grafanalabs-dev/docker-docs-previews-dev/${{ inputs.repo }}:${{ inputs.sha }}
+        service: deploy-preview-${{ inputs.repo }}-${{ inputs.event_number }}
+        project_id: grafanalabs-dev
+        region: us-south1
+        flags: --port=80 --ingress=all --allow-unauthenticated
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
+      if: github.event.action == 'closed'
+      with:
+        project_id: grafanalabs-dev
+
+    - name: Delete deploy preview
+      if: github.event.action == 'closed'
+      env:
+        REPO: ${{ inputs.repo }}
+        EVENT_NUMBER: ${{ inputs.event_number }}
+      run: |
+        SERVICE_NAME="deploy-preview-${REPO}-${EVENT_NUMBER}"
+        if gcloud run services describe $SERVICE_NAME --region=${{ env.CLOUD_RUN_REGION }} --project=grafanalabs-dev > /dev/null 2>&1; then
+          gcloud run services delete $SERVICE_NAME --region=${{ env.CLOUD_RUN_REGION }} --project=grafanalabs-dev --quiet
+        else
+          echo "Service $SERVICE_NAME does not exist. Skipping step."
+        fi
+
+    - name: Send commit status
+      uses: ouzi-dev/commit-status-updater@26588d166ff273fc4c0664517359948f7cdc9bf1 # v2.0.2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize'
+      with:
+        name: deploy_preview
+        status: "${{ job.status }}"
+        url: "${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}"
+        description: "Public deploy preview"
+
+    - name: Create comment with available deploy preview
+      if: (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id == ''
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ inputs.event_number }}
+        body: |
+          :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}
+
+    - name: Update comment with deleted deploy preview
+      if: github.event.action == 'closed'
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ inputs.event_number }}
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        edit-mode: replace
+        body: |
+          :computer: Deploy preview deleted.
+
+    - name: Update comment with available deploy preview
+      if: (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id != ''
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ inputs.event_number }}
+        edit-mode: replace
+        body: |
+          :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -2,6 +2,10 @@
 
 set -euf -o pipefail
 
+if [[ -n "${RUNNER_DEBUG+x}" ]]; then
+  set -x
+fi
+
 # All input comes from environment variables that are capitalized by convention in this script.
 SOURCES="${SOURCES:-[]}"
 

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -1,24 +1,73 @@
 #!/usr/bin/env bash
 
-docker run \
-  -v "${PWD}/dist:/hugo/dist" \
-  -v "${PWD}/${SOURCE_DIRECTORY}:/hugo/${WEBSITE_DIRECTORY}" \
-  -e INDEX_FILE \
-  -e REPO \
-  -e WEBSITE_DIRECTORY \
-  --rm grafana/docs-base:latest \
-  /bin/bash \
-    -c '
-if [[ "${INDEX_FILE}" == "true" ]]; then
-  echo "Creating custom _index.md" && \
-  cat > "/hugo/content/docs/${REPO}/_index.md" <<EOF
+set -euf -o pipefail
+
+# All input comes from environment variables that are capitalized by convention in this script.
+SOURCES="${SOURCES:-[]}"
+
+if ! jq -e . <<<"${SOURCES}" >/dev/null; then
+  echo "SOURCES environment variable is not valid JSON"
+fi
+
+tempfile="$(mktemp -t deploy-preview.XXX)"
+# Pull out the relevant fields from the JSON because the grafana/docs-base image doesn't have jq.
+index_files=()
+while read -r index_file relative_prefix; do
+  if [[ "${index_file}" != 'null' ]]; then
+    index_files+=("${index_file}:${relative_prefix}")
+  fi
+done < <(jq -r '.[] | "\(.index_file) \(.relative_prefix)"' <<<"${SOURCES}")
+cat <<EOSCRIPT >"${tempfile}"
+#!/usr/bin/env bash
+
+# Create an index file to redirect a project root to the correct versioned URL.
+for pair in ${index_files[@]}; do
+  IFS=':' read -r index_file relative_prefix <<<"\${pair}"
+  dst="/hugo/\${index_file}"
+  parent="\${dst%/*}"
+  echo "Creating custom index: \${dst} -> \${relative_prefix}"
+
+  title="\${dst%/*}"
+  while [[ -n "\${parent}" ]]; do
+    if [[ ! -f "\${parent}/_index.md" ]]; then
+       cat > "\${parent}/_index.md" <<EOPARENT
+---
+title: \${title}
+---
+
+# \${title}
+
+{{< section >}}
+EOPARENT
+    fi
+    parent="\${parent%/*}"
+  done
+
+  cat > "\${dst}" <<EOINDEX
 ---
 type: redirect
-redirectURL: /docs/${REPO}/latest/
+redirectURL: \${relative_prefix}
 versioned: true
 ---
-EOF
-fi
-cat "/hugo/content/docs/${REPO}/_index.md"
+EOINDEX
+  cat "\${dst}"
+done
+
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
-'
+EOSCRIPT
+chmod +x "${tempfile}"
+
+volumes=("--volume=${PWD}/dist:/hugo/dist" "--volume=${tempfile}:/entrypoint:z")
+while read -r source_directory website_directory; do
+  volumes+=("--volume=${PWD}/${source_directory}:/hugo/${website_directory}:z")
+done < <(jq -r '.[] | "\(.source_directory) \(.website_directory)"' <<<"${SOURCES}")
+
+IFS='' read -r cmd <<EOF
+docker run \
+  ${volumes[@]} \
+  --rm grafana/docs-base:latest \
+  /entrypoint
+EOF
+
+echo "${cmd}"
+${cmd}

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -39,3 +39,5 @@ If it's your first time using the guide, start with the [Get started](https://gr
 
 Writers' Toolkit is open source and available at [`grafana/writers-toolkit`](https://github.com/grafana/writers-toolkit).
 If you have questions, or feedback on how to improve this documentation, [open an issue](https://github.com/grafana/writers-toolkit/issues/new) and help make this an even better resource.
+
+Test deploy preview


### PR DESCRIPTION
This will want to come with a v2 release of the workflow given the breaking changes to the inputs.
I've also shifted the responsibility to check out the repository the caller so that we don't have to manage that ourselves.
I think this is most flexible as it lets the caller organize the workspace using as many repositories as they need (perhaps even using other repositories, `like grafana/enterprise-logs` alongside `grafana/loki`).

The action tries to be self-documenting.

I've been testing this out locally with the following command run from the root of the `grafana/mimir` repository: 

```console
SOURCES='[{"index_file": "content/docs/mimir/_index.md", "relative_prefix": "/docs/mimir/latest/", "source_directory": "docs/sources/mimir", "website_directory": "content/docs/mimir/latest"}, {"index_file": "content/docs/helm-charts/mimir-distributed/_index.md", "relative_prefix": "/docs/helm-charts/mimir-distributed/latest/", "source_directory": "docs/sources/helm-charts/mimir-distributed", "website_directory": "content/docs/helm-charts/mimir-distributed/latest"}]' "../writers-toolkit/deploy-preview/build.sh"
```

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
