### PR TITLE
Add Hugo package to Vale config to make it easy for other users to fetch the package

### DIFF
--- a/vale/.vale.ini
+++ b/vale/.vale.ini
@@ -1,5 +1,5 @@
 MinAlertLevel = suggestion
-Packages = Grafana
+Packages = Grafana, https://github.com/errata-ai/Hugo/releases/download/v0.2.0/Hugo.zip
 
 [*]
 BasedOnStyles = Grafana

--- a/vale/Makefile
+++ b/vale/Makefile
@@ -11,7 +11,6 @@ help: ## Display this help
 help:
 	@awk 'BEGIN {FS = ": ##"; printf "Usage:\n  make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_\.\-\/% ]+: ##/ { printf "  %-45s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-PODMAN := $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 SHORT_SHA := $(shell git rev-parse --short HEAD)
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
@@ -32,25 +31,23 @@ Grafana/styles/config/dictionaries/en_US-grafana.%: dictionary.libsonnet
 .PHONY: grafana/vale
 grafana/vale: ## Builds a container image for Vale with the Grafana style loaded.
 grafana/vale: Grafana/styles/config/dictionaries/en_US-grafana.aff Grafana/styles/config/dictionaries/en_US-grafana.dic Grafana/styles/Grafana/Google .vale.ini
-	podman manifest create --amend grafana/vale:latest
-	podman manifest create --amend grafana/vale:$(SHORT_SHA)
-	podman buildx build \
-		--manifest grafana/vale:latest \
+	docker buildx build \
 		--platform linux/x86_64,linux/arm64 \
-		--progress plain \
-			.
-	podman buildx build \
-		--manifest grafana/vale:$(SHORT_SHA) \
-		--platform linux/x86_64,linux/arm64 \
-		--progress plain \
-			.
+		--progress=plain \
+		--tag grafana/vale:$(SHORT_SHA) \
+		--tag grafana/vale:latest \
+		.
 
 .PHONY: grafana/vale/push
 grafana/vale/push: ## Builds and pushes container image for Vale with the Grafana style loaded.
-grafana/vale/push: grafana/vale
-	podman manifest push localhost/grafana/vale:latest docker://docker.io/grafana/vale:latest
-	podman manifest push localhost/grafana/vale:$(SHORT_SHA) docker://docker.io/grafana/vale:$(SHORT_SHA)
-
+grafana/vale/push:
+	docker buildx build \
+		--platform linux/x86_64,linux/arm64 \
+		--progress=plain \
+		--push \
+		--tag grafana/vale:$(SHORT_SHA) \
+		--tag grafana/vale:latest \
+		.
 .PHONY: sync
 sync: ## Update the vendored Google style.
 sync:


### PR DESCRIPTION
Useful in https://github.com/grafana/beyla/pull/1497.

There's differences in Podman and Docker multi-arch build CLIs, so I've switched to the most commonly used to make sure others can use the targets if need be.

- [x] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
