### PR TITLE
Docsc: Add CSV file and files to word list

### DIFF
--- a/vale/Google/WordList.yml
+++ b/vale/Google/WordList.yml
@@ -43,7 +43,6 @@ swap:
   Cloud: Google Cloud Platform|GCP
   Container Engine: Kubernetes Engine
   content type: media type
-
   curated roles: predefined roles
   data are: data is
   Developers Console: Google API Console|API Console

--- a/vale/Google/WordList.yml
+++ b/vale/Google/WordList.yml
@@ -43,6 +43,7 @@ swap:
   Cloud: Google Cloud Platform|GCP
   Container Engine: Kubernetes Engine
   content type: media type
+
   curated roles: predefined roles
   data are: data is
   Developers Console: Google API Console|API Console

--- a/vale/Grafana/styles/Grafana/WordList.yml
+++ b/vale/Grafana/styles/Grafana/WordList.yml
@@ -40,6 +40,8 @@
   "blacklists": "blocklists"
   "check[- ]box": "checkbox"
   "content type": "media type"
+  "CSV": "CSV file"
+  "CSVs": "CSV files"
   "data-?source": "data source"
   "data-?sources": "data sources"
   "data[- ]?set": "dataset"

--- a/vale/dictionary/c.jsonnet
+++ b/vale/dictionary/c.jsonnet
@@ -21,6 +21,6 @@ local word = import './word.jsonnet';
   word.new('CPU', 'S', 'noun') { abbreviation: true, elaboration: 'central processing unit', established_abbreviation: true },
   word.new('CRD', 'S', 'noun') { abbreviation: true, elaboration: 'Custom Resource Definition', established_abbreviation: true },
   word.new('CSS', '', 'noun') { abbreviation: true, elaboration: 'Cascading Style Sheets', established_abbreviation: true },
-  word.new('CSV', 'S', 'noun') { abbreviation: true, elaboration: 'Comma-separated values', established_abbreviation: true },
+  word.new('CSV', '', 'noun') { abbreviation: true, elaboration: 'Comma-separated values', established_abbreviation: true },
   word.new('CVE', 'S', 'noun'),
 ]


### PR DESCRIPTION
This PR
- Adds _CSV file_ and _CSV files_ as suggested replacements for _CSV_ and _CSVs_ in Word List
- Removes _CSVs_ from dictionary

Should have done this instead of adding _CSVs_ to the dictionary per [PR 967](https://github.com/grafana/writers-toolkit/pull/967) 🙃

