### PR TITLE
Require italics to explain abbreviations

### DIFF
--- a/docs/sources/review/lint-prose/rules.md
+++ b/docs/sources/review/lint-prose/rules.md
@@ -2,7 +2,7 @@
 date: "2024-06-25"
 description: A description of every Grafana Labs prose linting rule.
 menuTitle: Rules
-review_date: "2025-01-16"
+review_date: "2025-01-22"
 title: Vale rules
 ---
 
@@ -1083,7 +1083,7 @@ The following rules are suggestions to consider a certain point of style.
 
 Extends: conditional
 
-Spell out _`<CURRENT TEXT>`_, if it's unfamiliar to the audience.
+Spell out _`<CURRENT TEXT>`_, if it's unfamiliar to the audience. To spell out the abbreviation, you must enclose the full spelling and the abbreviation in parentheses, with italic emphasis. For example, _application programming interface (API)_.
 
 [More information ->](https://developers.google.com/style/abbreviations)
 

--- a/vale/Acronyms.jsonnet
+++ b/vale/Acronyms.jsonnet
@@ -1,13 +1,14 @@
 local defs = (import './dictionary.libsonnet').words;
 std.manifestYamlDoc({
   extends: 'conditional',
-  message: "Spell out '%s', if it's unfamiliar to the audience.",
+  message: "Spell out '%s', if it's unfamiliar to the audience. To spell out the abbreviation, you must enclose the full spelling and the abbreviation in parentheses, with italic emphasis. For example, _application programming interface (API)_.",
   link: 'https://developers.google.com/style/abbreviations',
   level: 'suggestion',
   ignorecase: false,
   // Ensures that the existence of 'first' implies the existence of 'second'.
   first: '\\b([A-Z]{3,5})\\b',
-  second: '(?:\\b[A-Z][a-z]+ )+\\(([A-Z]{3,5})\\)',
+  second: '_(?:[A-Za-z][a-z]+ )+\\(([A-Z]{3,5})\\)_',
+  scope: 'raw',
   // ... with the exception of these:
   exceptions: [
     '%s' % def.word

--- a/vale/Grafana/styles/Grafana/Acronyms.yml
+++ b/vale/Grafana/styles/Grafana/Acronyms.yml
@@ -75,5 +75,6 @@
 "ignorecase": false
 "level": "suggestion"
 "link": "https://developers.google.com/style/abbreviations"
-"message": "Spell out '%s', if it's unfamiliar to the audience."
-"second": "(?:\\b[A-Z][a-z]+ )+\\(([A-Z]{3,5})\\)"
+"message": "Spell out '%s', if it's unfamiliar to the audience. To spell out the abbreviation, you must enclose the full spelling and the abbreviation in parentheses, with italic emphasis. For example, _application programming interface (API)_."
+"scope": "raw"
+"second": "_(?:[A-Za-z][a-z]+ )+\\(([A-Z]{3,5})\\)_"

--- a/vale/Makefile
+++ b/vale/Makefile
@@ -20,7 +20,7 @@ STYLES := Grafana/styles/Grafana/Google Grafana/styles/Grafana/Readability
 RULES := Grafana/styles/Grafana/Acronyms.yml Grafana/styles/Grafana/AmazonProductNames.yml Grafana/styles/Grafana/ApacheProjectNames.yml Grafana/styles/Grafana/GoogleProductNames.yml Grafana/styles/Grafana/Headings.yml Grafana/styles/Grafana/ProductPossessives.yml Grafana/styles/Grafana/WordList.yml
 DOCUMENTATION := ../docs/sources/review/lint-prose/rules.md
 
-all: $(DICTIONARIES) $(DOCUMENTATION) $(RULES) $(STYLES) $(TESTS) ## Build all the Grafana Vale rules and styles.
+all: $(DICTIONARIES) $(DOCUMENTATION) $(RULES) $(STYLES) ## Build all the Grafana Vale rules and styles.
 $(DOCUMENTATION): $(wildcard Grafana/styles/Grafana/*) $(wildcard ../tools/cmd/generate-documentation/*)
 	cd ../tools/ && go run ./cmd/generate-documentation ../ tools/cmd/generate-documentation vale/Grafana/styles/Grafana docs/sources/review/lint-prose/rules.md
 	prettier -w $(DOCUMENTATION)


### PR DESCRIPTION
TODO: With raw scope, this captures lots of other uses of capitalized text like in placeholder variables.

Probably this would need to be a Tengo script.

- [ ] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
