### PR TITLE
Add rule to catch use of `grafana.com`

### DIFF
--- a/docs/sources/review/lint-prose/rules.md
+++ b/docs/sources/review/lint-prose/rules.md
@@ -2,7 +2,7 @@
 date: "2024-06-25"
 description: A description of every Grafana Labs prose linting rule.
 menuTitle: Rules
-review_date: "2025-01-23"
+review_date: "2025-01-24"
 title: Vale rules
 ---
 
@@ -57,6 +57,7 @@ The following is a list of all the rules that we've defined.
 <!-- vale Grafana.GoogleSpacing = NO -->
 <!-- vale Grafana.GoogleSpelling = NO -->
 <!-- vale Grafana.GoogleWill = NO -->
+<!-- vale Grafana.GrafanaCom = NO -->
 <!-- vale Grafana.Headings = NO -->
 <!-- vale Grafana.Kubernetes = NO -->
 <!-- vale Grafana.Latin = NO -->
@@ -665,6 +666,20 @@ _`<CURRENT TEXT>`_ was matched by one or more of the following regular expressio
 
 [More information ->](https://developers.google.com/style/tense)
 
+### Grafana.GrafanaCom
+
+Extends: existence
+
+Don't use `grafana.com`, instead use one of the following:
+
+- If you're talking about Grafana Cloud, use `Grafana Cloud`.
+- If you're talking about the company, use `Grafana Labs`.
+- If you're linking to a page on the website, use the page title or the full URL including scheme. For example, `https://grafana.com/`.
+
+_`<CURRENT TEXT>`_ was matched by one or more of the following regular expressions:
+
+- `grafana\.com`
+
 ### Grafana.Headings
 
 Extends: capitalization
@@ -1006,6 +1021,7 @@ Use _`<REPLACEMENT TEXT>`_ instead of _`<CURRENT TEXT>`_.
 | `blacklisted`                                                     | `blocklisted`              |
 | `blacklisting`                                                    | `blocklisting`             |
 | `blacklists`                                                      | `blocklists`               |
+| `cadvisor`                                                        | `cAdvisor`                 |
 | `check[- ]box`                                                    | `checkbox`                 |
 | `content type`                                                    | `media type`               |
 | `data-?source`                                                    | `data source`              |

--- a/vale/Grafana/styles/Grafana/GrafanaCom.yml
+++ b/vale/Grafana/styles/Grafana/GrafanaCom.yml
@@ -1,0 +1,11 @@
+extends: existence
+ignorecase: false
+level: warning
+message: |
+  Don't use `grafana.com`, instead use one of the following:
+
+  - If you're talking about Grafana Cloud, use `Grafana Cloud`.
+  - If you're talking about the company, use `Grafana Labs`.
+  - If you're linking to a page on the website, use the page title or the full URL including scheme. For example, `https://grafana.com/`.
+tokens:
+  - 'grafana\.com'

--- a/vale/Grafana/styles/Grafana/WordList.yml
+++ b/vale/Grafana/styles/Grafana/WordList.yml
@@ -41,6 +41,7 @@
   "blacklisted": "blocklisted"
   "blacklisting": "blocklisting"
   "blacklists": "blocklists"
+  "cadvisor": "cAdvisor"
   "check[- ]box": "checkbox"
   "content type": "media type"
   "data-?source": "data source"


### PR DESCRIPTION
Closes https://github.com/grafana/writers-toolkit/issues/988

https://deploy-preview-writers-toolkit-1002-zb444pucvq-vp.a.run.app/docs/writers-toolkit/review/lint-prose/rules/#grafanagrafanacom

- [x] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [x] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
