### PR TITLE
Fully implement `tags_only` release process

### DIFF
--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -122,7 +122,7 @@ runs:
 
     - name: Determine if there is a matching release tag
       id: has-matching-release-tag
-      if: github.ref_type == 'tag' && !inputs.tags_only
+      if: github.ref_type != 'tag'
       uses: ./actions/has-matching-release-tag
       with:
         ref_name: ${{ github.ref_name }}
@@ -131,14 +131,14 @@ runs:
         release_tag_regexp: ${{ inputs.release_tag_regexp }}
 
     - name: Determine technical documentation version
-      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: github.ref_type == 'tag' || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./actions/docs-target
       id: target
       with:
         ref_name: ${{ github.ref_name }}
 
     - name: Sync to the website repository (release)
-      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: github.ref_type == 'tag' || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./.github/actions/website-sync
       id: publish-release
       with:
@@ -151,7 +151,7 @@ runs:
         allow_no_changes: ${{ inputs.allow_no_changes }}
 
     - name: Print release outputs
-      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: github.ref_type == 'tag' || steps.has-matching-release-tag.outputs.bool == 'true'
       env:
         COMMIT_HASH: ${{ steps.publish-release.outputs.commit_hash }}
         WORKING_DIRECTORY: ${{ steps.publish-release.outputs.working_directory }}

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -66,7 +66,7 @@ runs:
       # Tags aren't necessarily made to the HEAD of the branch.
       # The documentation to be published is always on the HEAD of the branch.
       # However, if the repository only releases from tags, there's no release branch to check out.
-      if: github.ref_type == 'tag' && !inputs.tag_only
+      if: github.ref_type == 'tag' && !inputs.tags_only
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
         GITHUB_REF: ${{ github.ref }}
@@ -122,7 +122,7 @@ runs:
 
     - name: Determine if there is a matching release tag
       id: has-matching-release-tag
-      if: "!inputs.tag_only"
+      if: github.ref_type == 'tag' && !inputs.tags_only
       uses: ./actions/has-matching-release-tag
       with:
         ref_name: ${{ github.ref_name }}
@@ -131,14 +131,14 @@ runs:
         release_tag_regexp: ${{ inputs.release_tag_regexp }}
 
     - name: Determine technical documentation version
-      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./actions/docs-target
       id: target
       with:
         ref_name: ${{ github.ref_name }}
 
     - name: Sync to the website repository (release)
-      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./.github/actions/website-sync
       id: publish-release
       with:
@@ -151,7 +151,7 @@ runs:
         allow_no_changes: ${{ inputs.allow_no_changes }}
 
     - name: Print release outputs
-      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tags_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       env:
         COMMIT_HASH: ${{ steps.publish-release.outputs.commit_hash }}
         WORKING_DIRECTORY: ${{ steps.publish-release.outputs.working_directory }}

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -84,7 +84,8 @@ runs:
       shell: bash
 
     - name: Build website
-      uses: grafana/writers-toolkit/build-website@4b1248585248751e3b12fd020cf7ac91540ca09c # build-website/v1.0.1      with:
+      uses: grafana/writers-toolkit/build-website@4b1248585248751e3b12fd020cf7ac91540ca09c # build-website/v1.0.1
+      with:
         source_directory: ${{ inputs.source_directory }}
         website_directory: ${{ inputs.website_directory }}
 
@@ -121,6 +122,7 @@ runs:
 
     - name: Determine if there is a matching release tag
       id: has-matching-release-tag
+      if: "!inputs.tag_only"
       uses: ./actions/has-matching-release-tag
       with:
         ref_name: ${{ github.ref_name }}
@@ -129,14 +131,14 @@ runs:
         release_tag_regexp: ${{ inputs.release_tag_regexp }}
 
     - name: Determine technical documentation version
-      if: steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./actions/docs-target
       id: target
       with:
         ref_name: ${{ github.ref_name }}
 
     - name: Sync to the website repository (release)
-      if: steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       uses: ./.github/actions/website-sync
       id: publish-release
       with:
@@ -149,7 +151,7 @@ runs:
         allow_no_changes: ${{ inputs.allow_no_changes }}
 
     - name: Print release outputs
-      if: steps.has-matching-release-tag.outputs.bool == 'true'
+      if: (github.ref_type == 'tag' && !inputs.tag_only) || steps.has-matching-release-tag.outputs.bool == 'true'
       env:
         COMMIT_HASH: ${{ steps.publish-release.outputs.commit_hash }}
         WORKING_DIRECTORY: ${{ steps.publish-release.outputs.working_directory }}


### PR DESCRIPTION
Some steps don't need to run when a project only releases from tags and doesn't maintain release branches.

<!--
Thank you for contributing to Writers' Toolkit!

Consider the following checklist to make sure your PR is most effective.
-->

- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
