### PR TITLE
Replace individual inputs with JSON string array of inputs

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,16 +9,24 @@ on:
     paths:
       - "docs/sources/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.repo }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-pr-preview:
+    if: "!github.event.pull_request.head.repo.fork"
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
     with:
-      sha: ${{ github.event.pull_request.head.sha }}
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      sources: |
+        [{
+            "index_file": null,
+            "relative_prefix": "/docs/writers-toolkit/",
+            "repo": writers-toolkit",
+            "source_directory": "docs/sources",
+            "website_directory": "content/docs/writers-toolkit"
+        }]
       title: ${{ github.event.pull_request.title }}
-      repo: writers-toolkit
-      website_directory: content/docs/writers-toolkit
-      relative_prefix: /docs/writers-toolkit/
-      index_file: false

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,10 +9,6 @@ on:
     paths:
       - "docs/sources/**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ inputs.repo }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -18,7 +18,7 @@ jobs:
       event_number: ${{ github.event.number }}
       sha: ${{ github.event.pull_request.head.sha }}
       sources: |
-        [{
+        '[{
             "index_file": null,
             "relative_prefix": "/docs/writers-toolkit/",
             "repo": writers-toolkit",

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   deploy-pr-preview:
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@jdb/deploy-preview
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}
+      repo: writers-toolkit
       sha: ${{ github.event.pull_request.head.sha }}
       sources: |
         [{

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -18,11 +18,11 @@ jobs:
       event_number: ${{ github.event.number }}
       sha: ${{ github.event.pull_request.head.sha }}
       sources: |
-        '[{
+        [{
             "index_file": null,
             "relative_prefix": "/docs/writers-toolkit/",
-            "repo": writers-toolkit",
+            "repo": "writers-toolkit",
             "source_directory": "docs/sources",
             "website_directory": "content/docs/writers-toolkit"
-        }]'
+        }]
       title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -24,5 +24,5 @@ jobs:
             "repo": writers-toolkit",
             "source_directory": "docs/sources",
             "website_directory": "content/docs/writers-toolkit"
-        }]
+        }]'
       title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -125,6 +125,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           SOURCES: ${{ inputs.SOURCES }}
         run: |
           ./deploy-preview-files/deploy-preview/build.sh

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -115,13 +115,10 @@ jobs:
       - name: Keep only necessary files
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
-        env:
-          SOURCE_DIRECTORY: ${{ inputs.source_directory }}
         run: |
           shopt -s extglob
           rm -rf !(deploy-preview-files|.git)
-          ls -al
-          ls -al "${SOURCE_DIRECTORY}"
+          ls -al .
           ls -al deploy-preview-files
 
       - name: Build website

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -127,7 +127,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: jdb/deploy-preview
+          ref: main
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,6 +3,54 @@ name: deploy-preview
 on:
   workflow_call:
     inputs:
+      sources:
+        description: |
+          sources is a JSON string describing multiple source mounts.
+
+          It replaces the individual inputs used in the previous version of this action.
+
+          The structure is an array of objects, each with the following keys:
+
+          index_file:
+            description: Path to index file used to redirect versioned projects. For example, "content/docs/mimir/_index.md".
+            required: true
+            type: string
+          relative_prefix:
+            description: The URL path prefix for the mount destination. For example, "/docs/mimir/latest/".
+            required: true
+            type: string
+          repo:
+            description: The Grafana repository name for the source files. For example, "mimir".
+            required: true
+            type: string
+          source_directory:
+            description: The path to the source files in the repository. For example, "docs/sources".
+            required: true
+            type: string
+          website_directory:
+            description: The path to mount the documentation in the website content structure. For example, "content/docs/mimir/latest".
+            required: true
+            type: string
+
+          The following example mounts both the Mimir documentation and the mimir-distributed Helm chart documentation:
+
+          [
+            {
+              "index_file": true,
+              "relative_prefix": "/docs/mimir/latest/",
+              "repo": "mimir",
+              "source_directory": "docs/sources/mimir",
+              "website_directory": "content/docs/mimir/latest"
+            },
+            {
+              "index_file": true,
+              "relative_prefix": "/docs/helm-charts/mimir-distributed/latest/",
+              "repo": "mimir",
+              "source_directory": "docs/sources/mimir-distributed",
+              "website_directory": "content/docs/helm-charts/mimir-distributed/latest"
+            }
+          ]
+        type: string
       sha:
         required: true
         type: string
@@ -15,21 +63,6 @@ on:
       title:
         required: true
         type: string
-      repo:
-        required: true
-        type: string
-      source_directory:
-        default: docs/sources
-        type: string
-      website_directory:
-        required: true
-        type: string
-      relative_prefix:
-        required: true
-        type: string
-      index_file: # creates the necessary project _index.md file for versioned repos
-        required: true
-        type: boolean
 
 env:
   CLOUD_RUN_REGION: us-south1
@@ -41,7 +74,7 @@ concurrency:
 jobs:
   deploy-preview:
     permissions:
-      contents: read
+      contents: read # Clone repositories.
       id-token: write # Fetch Vault secrets.
       pull-requests: write # Create or update PR comments.
       statuses: write # Update GitHub status check with deploy preview link.
@@ -66,20 +99,12 @@ jobs:
           body: |
             :building_construction: Updating deploy preview...
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
-        with:
-          persist-credentials: false
-          sparse-checkout-cone-mode: false # exclude root files
-          sparse-checkout: docs
-
-      # get the Dockerfile and nginx conf
       - name: Sparse checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: "main"
+          ref: jdb/2025-01-multiple-source-deploy-preview
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |
@@ -94,7 +119,7 @@ jobs:
           SOURCE_DIRECTORY: ${{ inputs.source_directory }}
         run: |
           shopt -s extglob
-          rm -rf !(docs|deploy-preview-files|.git)
+          rm -rf !(deploy-preview-files|.git)
           ls -al
           ls -al "${SOURCE_DIRECTORY}"
           ls -al deploy-preview-files
@@ -103,10 +128,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         env:
-          SOURCE_DIRECTORY: ${{ inputs.source_directory }}
-          WEBSITE_DIRECTORY: ${{ inputs.website_directory }}
-          INDEX_FILE: ${{ inputs.index_file }}
-          REPO: ${{ inputs.repo }}
+          SOURCES: ${{ inputs.SOURCES }}
         run: |
           ./deploy-preview-files/deploy-preview/build.sh
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -130,8 +130,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCES: ${{ inputs.SOURCES }}
-        run: |
-          ./deploy-preview-files/deploy-preview/build.sh
+        run: ./deploy-preview-files/deploy-preview/build
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -230,13 +229,23 @@ jobs:
           url: "${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}"
           description: "Public deploy preview"
 
+      - name: Get preview URLs
+        id: urls
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        shell: bash
+        env:
+          SOURCES: ${{ inputs.SOURCES }}
+          URL: ${{ steps.deploy.outputs.url }}
+        run: ./deploy-preview-files/deploy-preview/urls
+
       - name: Create comment with available deploy preview
         if: (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ inputs.event_number }}
           body: |
-            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}
+            :computer: Deploy preview available:
+            ${{ steps.urls.outputs.urls }}
 
       - name: Update comment with deleted deploy preview
         if: github.event.action == 'closed'
@@ -256,4 +265,5 @@ jobs:
           issue-number: ${{ inputs.event_number }}
           edit-mode: replace
           body: |
-            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}
+            :computer: Deploy preview available:
+            ${{ steps.urls.outputs.urls }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -104,7 +104,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: jdb/2025-01-multiple-source-deploy-preview
+          ref: jdb/deploy-preview
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -68,7 +68,7 @@ env:
   CLOUD_RUN_REGION: us-south1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.repo }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -60,6 +60,9 @@ on:
       event_number:
         required: true
         type: string
+      repo:
+        required: true
+        type: string
       title:
         required: true
         type: string
@@ -68,7 +71,7 @@ env:
   CLOUD_RUN_REGION: us-south1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.repo }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,17 +4,15 @@ on:
   workflow_call:
     inputs:
       # Legacy inputs
+      # Don't forget to make `sources` required when you remove these.
       source_directory:
         default: docs/sources
         type: string
       website_directory:
-        required: true
         type: string
       relative_prefix:
-        required: true
         type: string
       index_file: # creates the necessary project _index.md file for versioned repos
-        required: true
         type: boolean
       # End legacy inputs
       sources:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -130,6 +130,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCES: ${{ inputs.SOURCES }}
+          BRANCH: ${{ inputs.branch }}
         run: ./deploy-preview-files/deploy-preview/build
 
       - name: Print build header value

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,6 +3,20 @@ name: deploy-preview
 on:
   workflow_call:
     inputs:
+      # Legacy inputs
+      source_directory:
+        default: docs/sources
+        type: string
+      website_directory:
+        required: true
+        type: string
+      relative_prefix:
+        required: true
+        type: string
+      index_file: # creates the necessary project _index.md file for versioned repos
+        required: true
+        type: boolean
+      # End legacy inputs
       sources:
         description: |
           sources is a JSON string describing multiple source mounts.
@@ -102,6 +116,14 @@ jobs:
           body: |
             :building_construction: Updating deploy preview...
 
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')
+        with:
+          persist-credentials: false
+          sparse-checkout-cone-mode: false # exclude root files
+          sparse-checkout: docs
+
       - name: Sparse checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -113,10 +135,22 @@ jobs:
           sparse-checkout: |
             deploy-preview
 
+      - name: Keep only necessary files
+        if: inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')
+        shell: bash
+        env:
+          SOURCE_DIRECTORY: ${{ inputs.source_directory }}
+        run: |
+          shopt -s extglob
+          rm -rf !(docs|deploy-preview-files|.git)
+          ls -al
+          ls -al "${SOURCE_DIRECTORY}"
+          ls -al deploy-preview-files
+
       # sparse checkout with cone mode disabled includes root files, even when using exclusions
       # see https://github.com/actions/checkout/issues/1430#issuecomment-1756326892
       - name: Keep only necessary files
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        if: "!inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')"
         shell: bash
         run: |
           shopt -s extglob
@@ -128,6 +162,12 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         shell: bash
         env:
+          # Legacy input.
+          SOURCE_DIRECTORY: ${{ inputs.source_directory }}
+          WEBSITE_DIRECTORY: ${{ inputs.website_directory }}
+          INDEX_FILE: ${{ inputs.index_file }}
+          REPO: ${{ inputs.repo }}
+          # End legacy input.
           GH_TOKEN: ${{ github.token }}
           SOURCES: ${{ inputs.SOURCES }}
           BRANCH: ${{ inputs.branch }}
@@ -223,7 +263,15 @@ jobs:
 
       - name: Send commit status
         uses: ouzi-dev/commit-status-updater@26588d166ff273fc4c0664517359948f7cdc9bf1 # v2.0.2
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        if: inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')
+        with:
+          name: deploy_preview
+          status: "${{ job.status }}"
+          url: "${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}"
+
+      - name: Send commit status
+        uses: ouzi-dev/commit-status-updater@26588d166ff273fc4c0664517359948f7cdc9bf1 # v2.0.2
+        if: "!inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')"
         with:
           name: deploy_preview
           status: "${{ job.status }}"
@@ -232,7 +280,7 @@ jobs:
 
       - name: Get preview URLs
         id: urls
-        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        if: "!inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize')"
         shell: bash
         env:
           SOURCES: ${{ inputs.SOURCES }}
@@ -240,7 +288,15 @@ jobs:
         run: ./deploy-preview-files/deploy-preview/urls
 
       - name: Create comment with available deploy preview
-        if: (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id == ''
+        if: inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ inputs.event_number }}
+          body: |
+            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}
+
+      - name: Create comment with available deploy preview
+        if: "!inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id == ''"
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ inputs.event_number }}
@@ -258,8 +314,19 @@ jobs:
           body: |
             :computer: Deploy preview deleted.
 
+
       - name: Update comment with available deploy preview
-        if: (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id != ''
+        if: inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ inputs.event_number }}
+          edit-mode: replace
+          body: |
+            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}
+
+      - name: Update comment with available deploy preview
+        if: "!inputs.website_directory && (github.event.action == 'opened' || github.event.action == 'synchronize') && steps.fc.outputs.comment-id != ''"
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -227,7 +227,7 @@ jobs:
         with:
           name: deploy_preview
           status: "${{ job.status }}"
-          url: "${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}"
+          url: "${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}"
           description: "Public deploy preview"
 
       - name: Create comment with available deploy preview
@@ -236,7 +236,7 @@ jobs:
         with:
           issue-number: ${{ inputs.event_number }}
           body: |
-            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}
+            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}
 
       - name: Update comment with deleted deploy preview
         if: github.event.action == 'closed'
@@ -256,4 +256,4 @@ jobs:
           issue-number: ${{ inputs.event_number }}
           edit-mode: replace
           body: |
-            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ inputs.relative_prefix }}
+            :computer: Deploy preview available: ${{ steps.deploy.outputs.url }}${{ (fromJSON(inputs.sources))[0].relative_prefix }}

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -6,61 +6,94 @@ if [[ -n "${RUNNER_DEBUG+x}" ]]; then
   set -x
 fi
 
-# All input comes from environment variables that are capitalized by convention in this script.
-readonly SOURCES="${SOURCES:-[]}"
-readonly BRANCH="${BRANCH:-}"
+# Legacy build.
+if [[ -z "${WEBSITE_DIRECTORY+x}" ]]; then
+  echo "::warning ::Using legacy inputs. Reach out to #docs-platform (https://raintank-corp.slack.com/archives/C07R2REUULS) to update."
 
-if ! jq -e . <<<"${SOURCES}" >/dev/null; then
-  echo "SOURCES environment variable is not valid JSON"
+  readonly WEBSITE_DIRECTORY="${WEBSITE_DIRECTORY:-}"
+  readonly SOURCE_DIRECTORY="${SOURCE_DIRECTORY:-}"
+  readonly REPO="${REPO:-}"
+  readonly INDEX_FILE="${INDEX_FILE:-false}"
 
-  exit 1
+  docker run \
+         -v "${PWD}/dist:/hugo/dist" \
+         -v "${PWD}/${SOURCE_DIRECTORY}:/hugo/${WEBSITE_DIRECTORY}" \
+         -e INDEX_FILE \
+         -e REPO \
+         -e WEBSITE_DIRECTORY \
+         --rm grafana/docs-base:latest \
+         /bin/bash \
+         -c '
+if [[ "${INDEX_FILE}" == "true" ]]; then
+  echo "Creating custom _index.md" && \
+  cat > "/hugo/content/docs/${REPO}/_index.md" <<EOF
+---
+type: redirect
+redirectURL: /docs/${REPO}/latest/
+versioned: true
+---
+EOF
 fi
+cat "/hugo/content/docs/${REPO}/_index.md"
+HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
+'
+# End legacy input.
+else
+  # All input comes from environment variables that are capitalized by convention in this script.
+  readonly SOURCES="${SOURCES:-[]}"
+  readonly BRANCH="${BRANCH:-}"
 
-if [[ -z "${BRANCH+x}" ]]; then
-  echo "BRANCH environment variable is not set. It should be the PR branch name."
+  if ! jq -e . <<<"${SOURCES}" >/dev/null; then
+    echo "SOURCES environment variable is not valid JSON"
 
-  exit 1
-fi
-
-# Clone a repository to a specific directory.
-function clone {
-  local repo=$1
-  local directory=$2
-
-  if [[ -d "${directory}" ]]; then
-    echo "Directory ${directory} already exists, skipping clone"
-
-    return
+    exit 1
   fi
 
-  gh repo clone "grafana/${repo}" "${directory}"
-  (cd "${directory}" && gh pr checkout "${BRANCH}")
-}
+  if [[ -z "${BRANCH+x}" ]]; then
+    echo "BRANCH environment variable is not set. It should be the PR branch name."
 
-# Check out all the source repositories defined in SOURCES.
-function check_out_sources {
-  index_files=()
-  while read -r repo; do
-    if [[ -z "${repo}" ]]; then
-      continue
+    exit 1
+  fi
+
+  # Clone a repository to a specific directory.
+  function clone {
+    local repo=$1
+    local directory=$2
+
+    if [[ -d "${directory}" ]]; then
+      echo "Directory ${directory} already exists, skipping clone"
+
+      return
     fi
 
-    clone "${repo}" "src/${repo}"
+    gh repo clone "grafana/${repo}" "${directory}"
+    (cd "${directory}" && gh pr checkout "${BRANCH}")
+  }
 
-  done < <(jq -r '.[].repo' <<<"${SOURCES}")
-}
+  # Check out all the source repositories defined in SOURCES.
+  function check_out_sources {
+    index_files=()
+    while read -r repo; do
+      if [[ -z "${repo}" ]]; then
+        continue
+      fi
 
-# Create an entrypoint script for the container.
-function prepare_entrypoint {
-  tempfile="$(mktemp -t deploy-preview.XXX)"
-  # Pull out the relevant fields from the JSON because the grafana/docs-base image doesn't have jq.
-  index_files=()
-  while read -r index_file relative_prefix; do
-    if [[ "${index_file}" != 'null' ]]; then
-      index_files+=("${index_file}:${relative_prefix}")
-    fi
-  done < <(jq -r '.[] | "\(.index_file) \(.relative_prefix)"' <<<"${SOURCES}")
-  cat <<EOSCRIPT >"${tempfile}"
+      clone "${repo}" "src/${repo}"
+
+    done < <(jq -r '.[].repo' <<<"${SOURCES}")
+  }
+
+  # Create an entrypoint script for the container.
+  function prepare_entrypoint {
+    tempfile="$(mktemp -t deploy-preview.XXX)"
+    # Pull out the relevant fields from the JSON because the grafana/docs-base image doesn't have jq.
+    index_files=()
+    while read -r index_file relative_prefix; do
+      if [[ "${index_file}" != 'null' ]]; then
+        index_files+=("${index_file}:${relative_prefix}")
+      fi
+    done < <(jq -r '.[] | "\(.index_file) \(.relative_prefix)"' <<<"${SOURCES}")
+    cat <<EOSCRIPT >"${tempfile}"
 #!/usr/bin/env bash
 
 # Create an index file to redirect a project root to the correct versioned URL.
@@ -98,31 +131,32 @@ done
 
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
 EOSCRIPT
-  chmod +x "${tempfile}"
-}
+    chmod +x "${tempfile}"
+  }
 
-# Add mounts to the volumes variable.
-function configure_volumes {
-  volumes=("--volume=${PWD}/dist:/hugo/dist" "--volume=${tempfile}:/entrypoint:z")
-  while read -r repo source_directory website_directory; do
-    volumes+=("--volume=${PWD}/src/${repo}/${source_directory}:/hugo/${website_directory}:z")
-  done < <(jq -r '.[] | "\(.repo) \(.source_directory) \(.website_directory)"' <<<"${SOURCES}")
-}
+  # Add mounts to the volumes variable.
+  function configure_volumes {
+    volumes=("--volume=${PWD}/dist:/hugo/dist" "--volume=${tempfile}:/entrypoint:z")
+    while read -r repo source_directory website_directory; do
+      volumes+=("--volume=${PWD}/src/${repo}/${source_directory}:/hugo/${website_directory}:z")
+    done < <(jq -r '.[] | "\(.repo) \(.source_directory) \(.website_directory)"' <<<"${SOURCES}")
+  }
 
-# Prepare the command to run the container.
-function prepare_cmd {
-  cat <<EOF
+  # Prepare the command to run the container.
+  function prepare_cmd {
+    cat <<EOF
 docker run \
 ${volumes[@]} \
 --rm grafana/docs-base:latest \
 /entrypoint
 EOF
-}
+  }
 
-check_out_sources
-prepare_entrypoint
-declare -a volumes; configure_volumes; readonly volumes
-cmd=$(prepare_cmd)
+  check_out_sources
+  prepare_entrypoint
+  declare -a volumes; configure_volumes; readonly volumes
+  cmd=$(prepare_cmd)
 
-echo "${cmd}"
-${cmd}
+  echo "${cmd}"
+  ${cmd}
+fi

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -34,7 +34,7 @@ function clone {
   fi
 
   gh repo clone "grafana/${repo}" "${directory}"
-  gh pr checkout "${BRANCH}"
+  (cd "${directory}" && gh pr checkout "${BRANCH}")
 }
 
 # Check out all the source repositories defined in SOURCES.

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -7,7 +7,7 @@ if [[ -n "${RUNNER_DEBUG+x}" ]]; then
 fi
 
 # All input comes from environment variables that are capitalized by convention in this script.
-SOURCES="${SOURCES:-[]}"
+readonly SOURCES="${SOURCES:-[]}"
 
 if ! jq -e . <<<"${SOURCES}" >/dev/null; then
   echo "SOURCES environment variable is not valid JSON"

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -8,9 +8,16 @@ fi
 
 # All input comes from environment variables that are capitalized by convention in this script.
 readonly SOURCES="${SOURCES:-[]}"
+readonly BRANCH="${BRANCH:-}"
 
 if ! jq -e . <<<"${SOURCES}" >/dev/null; then
   echo "SOURCES environment variable is not valid JSON"
+
+  exit 1
+fi
+
+if [[ -z "${BRANCH+x}" ]]; then
+  echo "BRANCH environment variable is not set. It should be the PR branch name."
 
   exit 1
 fi
@@ -27,6 +34,7 @@ function clone {
   fi
 
   gh repo clone "grafana/${repo}" "${directory}"
+  gh pr checkout "${BRANCH}"
 }
 
 # Check out all the source repositories defined in SOURCES.

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -1,24 +1,118 @@
 #!/usr/bin/env bash
 
-docker run \
-  -v "${PWD}/dist:/hugo/dist" \
-  -v "${PWD}/${SOURCE_DIRECTORY}:/hugo/${WEBSITE_DIRECTORY}" \
-  -e INDEX_FILE \
-  -e REPO \
-  -e WEBSITE_DIRECTORY \
-  --rm grafana/docs-base:latest \
-  /bin/bash \
-    -c '
-if [[ "${INDEX_FILE}" == "true" ]]; then
-  echo "Creating custom _index.md" && \
-  cat > "/hugo/content/docs/${REPO}/_index.md" <<EOF
+set -euf -o pipefail
+
+if [[ -n "${RUNNER_DEBUG+x}" ]]; then
+  set -x
+fi
+
+# All input comes from environment variables that are capitalized by convention in this script.
+SOURCES="${SOURCES:-[]}"
+
+if ! jq -e . <<<"${SOURCES}" >/dev/null; then
+  echo "SOURCES environment variable is not valid JSON"
+fi
+
+# Clone a repository to a specific directory.
+function clone {
+  local repo=$1
+  local directory=$2
+
+  if [[ -d "${directory}" ]]; then
+    echo "Directory ${directory} already exists, skipping clone"
+
+    return
+  fi
+
+  gh repo clone "grafana/${repo}" "${directory}"
+}
+
+# Check out all the source repositories defined in SOURCES.
+function check_out_sources {
+  index_files=()
+  while read -r repo; do
+    if [[ -z "${repo}" ]]; then
+      continue
+    fi
+
+    clone "${repo}" "src/${repo}"
+
+  done < <(jq -r '.[].repo' <<<"${SOURCES}")
+}
+
+# Create an entrypoint script for the container.
+function prepare_entrypoint {
+  tempfile="$(mktemp -t deploy-preview.XXX)"
+  # Pull out the relevant fields from the JSON because the grafana/docs-base image doesn't have jq.
+  index_files=()
+  while read -r index_file relative_prefix; do
+    if [[ "${index_file}" != 'null' ]]; then
+      index_files+=("${index_file}:${relative_prefix}")
+    fi
+  done < <(jq -r '.[] | "\(.index_file) \(.relative_prefix)"' <<<"${SOURCES}")
+  cat <<EOSCRIPT >"${tempfile}"
+#!/usr/bin/env bash
+
+# Create an index file to redirect a project root to the correct versioned URL.
+for pair in ${index_files[@]}; do
+  IFS=':' read -r index_file relative_prefix <<<"\${pair}"
+  dst="/hugo/\${index_file}"
+  parent="\${dst%/*}"
+  echo "Creating custom index: \${dst} -> \${relative_prefix}"
+
+  title="\${dst%/*}"
+  while [[ -n "\${parent}" ]]; do
+    if [[ ! -f "\${parent}/_index.md" ]]; then
+       cat > "\${parent}/_index.md" <<EOPARENT
+---
+title: \${title}
+---
+
+# \${title}
+
+{{< section >}}
+EOPARENT
+    fi
+    parent="\${parent%/*}"
+  done
+
+  cat > "\${dst}" <<EOINDEX
 ---
 type: redirect
-redirectURL: /docs/${REPO}/latest/
+redirectURL: \${relative_prefix}
 versioned: true
 ---
-EOF
-fi
-cat "/hugo/content/docs/${REPO}/_index.md"
+EOINDEX
+  cat "\${dst}"
+done
+
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
-'
+EOSCRIPT
+  chmod +x "${tempfile}"
+}
+
+# Add mounts to the volumes variable.
+function configure_volumes {
+  volumes=("--volume=${PWD}/dist:/hugo/dist" "--volume=${tempfile}:/entrypoint:z")
+  while read -r repo source_directory website_directory; do
+    volumes+=("--volume=${PWD}/src/${repo}/${source_directory}:/hugo/${website_directory}:z")
+  done < <(jq -r '.[] | "\(.repo) \(.source_directory) \(.website_directory)"' <<<"${SOURCES}")
+}
+
+# Prepare the command to run the container.
+function prepare_cmd {
+  cat <<EOF
+docker run \
+${volumes[@]} \
+--rm grafana/docs-base:latest \
+/entrypoint
+EOF
+}
+
+check_out_sources
+prepare_entrypoint
+declare -a volumes; configure_volumes; readonly volumes
+cmd=$(prepare_cmd)
+
+echo "${cmd}"
+${cmd}

--- a/deploy-preview/build.sh
+++ b/deploy-preview/build.sh
@@ -11,6 +11,8 @@ SOURCES="${SOURCES:-[]}"
 
 if ! jq -e . <<<"${SOURCES}" >/dev/null; then
   echo "SOURCES environment variable is not valid JSON"
+
+  exit 1
 fi
 
 # Clone a repository to a specific directory.

--- a/deploy-preview/urls
+++ b/deploy-preview/urls
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+if [[ -n "${RUNNER_DEBUG+x}" ]]; then
+  set -x
+fi
+
+# All input comes from environment variables that are capitalized by convention in this script.
+readonly GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+readonly SOURCES="${SOURCES:-[]}"
+readonly URL="${URL:-}"
+
+if ! jq -e . <<<"${SOURCES}" >/dev/null; then
+  echo "SOURCES environment variable is not valid JSON"
+
+  exit 1
+fi
+
+urls=()
+while read -r relative_prefix; do
+  urls+=("- ${URL}${relative_prefix}")
+done < <(jq -r '.[].relative_prefix' <<<"${SOURCES}")
+readonly urls
+
+(IFS=$'\n'; echo "urls=${urls[*]}" >> "${GITHUB_OUTPUT}")

--- a/deploy-preview/urls
+++ b/deploy-preview/urls
@@ -23,4 +23,6 @@ while read -r relative_prefix; do
 done < <(jq -r '.[].relative_prefix' <<<"${SOURCES}")
 readonly urls
 
+echo "URLS<<EOF" >> "${GITHUB_OUTPUT}"
 (IFS=$'\n'; echo "urls=${urls[*]}" >> "${GITHUB_OUTPUT}")
+echo "EOF" >> "${GITHUB_OUTPUT}"

--- a/deploy-preview/urls
+++ b/deploy-preview/urls
@@ -19,6 +19,6 @@ fi
 
 echo "urls<<EOF" >> "${GITHUB_OUTPUT}"
 while read -r relative_prefix; do
-  urls+=("- ${URL}${relative_prefix}")
+  echo "- ${URL}${relative_prefix}" >> "${GITHUB_OUTPUT}"
 done < <(jq -r '.[].relative_prefix' <<<"${SOURCES}")
 echo "EOF" >> "${GITHUB_OUTPUT}"

--- a/deploy-preview/urls
+++ b/deploy-preview/urls
@@ -21,8 +21,4 @@ urls=()
 while read -r relative_prefix; do
   urls+=("- ${URL}${relative_prefix}")
 done < <(jq -r '.[].relative_prefix' <<<"${SOURCES}")
-readonly urls
-
-echo "URLS<<EOF" >> "${GITHUB_OUTPUT}"
-(IFS=$'\n'; echo "urls=${urls[*]}" >> "${GITHUB_OUTPUT}")
 echo "EOF" >> "${GITHUB_OUTPUT}"

--- a/deploy-preview/urls
+++ b/deploy-preview/urls
@@ -17,7 +17,7 @@ if ! jq -e . <<<"${SOURCES}" >/dev/null; then
   exit 1
 fi
 
-urls=()
+echo "urls<<EOF" >> "${GITHUB_OUTPUT}"
 while read -r relative_prefix; do
   urls+=("- ${URL}${relative_prefix}")
 done < <(jq -r '.[].relative_prefix' <<<"${SOURCES}")

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -39,3 +39,5 @@ If it's your first time using the guide, start with the [Get started](https://gr
 
 Writers' Toolkit is open source and available at [`grafana/writers-toolkit`](https://github.com/grafana/writers-toolkit).
 If you have questions, or feedback on how to improve this documentation, [open an issue](https://github.com/grafana/writers-toolkit/issues/new) and help make this an even better resource.
+
+Test deploy preview


### PR DESCRIPTION
This lets us build multiples sources in a single deploy preview as demonstrated in https://github.com/grafana/mimir/pull/10580.

I also think it allows us to mount source projects into Grafana Cloud documentation directly instead of a publishing directory although it doesn't use Hugo mounts for that.

Let me know if you'd like me to test anything specifically out for you so you can be confident in the changes.

This can be rolled out safely as tested in:
- [Legacy inputs](https://github.com/grafana/fleet-management/actions/runs/13409179066/workflow?pr=490)
- [New inputs](https://github.com/grafana/writers-toolkit/actions/runs/13409334007/job/37455648763?pr=1014)

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

- [x] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [x] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
