### PR TITLE
Docs: Add video-embed shortcode to Shortcode page

### DIFF
--- a/docs/sources/whats-new.md
+++ b/docs/sources/whats-new.md
@@ -24,7 +24,7 @@ This page provides a summary of notable changes to Writers' Toolkit guidance.
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Fixed the path to the section template file.                          | https://raw.githubusercontent.com/grafana/writers-toolkit/refs/heads/main/docs/static/templates/section-template.md |
 | Added `topic/<TYPE>` Make targets to create a topic from its template | [Topic types](/docs/writers-toolkit/structure/topic-types/)                                                         |
-| Added `video-embed` to Shortcodes page. | [Shortcodes](/docs/writers-toolkit/write/shortcodes/#video-embed)                                                         |
+| Added `video-embed` to Shortcodes page.                               | [Shortcodes](/docs/writers-toolkit/write/shortcodes/#video-embed)                                                   |
 
 ## January 2025
 

--- a/docs/sources/whats-new.md
+++ b/docs/sources/whats-new.md
@@ -24,7 +24,7 @@ This page provides a summary of notable changes to Writers' Toolkit guidance.
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Fixed the path to the section template file.                          | https://raw.githubusercontent.com/grafana/writers-toolkit/refs/heads/main/docs/static/templates/section-template.md |
 | Added `topic/<TYPE>` Make targets to create a topic from its template | [Topic types](/docs/writers-toolkit/structure/topic-types/)                                                         |
-| Added `video-embed` to Shortcodes page. | [Shortcodes](/docs/writers-toolkit/write/shortcodes/)                                                         |
+| Added `video-embed` to Shortcodes page. | [Shortcodes](/docs/writers-toolkit/write/shortcodes/#video-embed)                                                         |
 
 ## January 2025
 

--- a/docs/sources/whats-new.md
+++ b/docs/sources/whats-new.md
@@ -24,6 +24,7 @@ This page provides a summary of notable changes to Writers' Toolkit guidance.
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Fixed the path to the section template file.                          | https://raw.githubusercontent.com/grafana/writers-toolkit/refs/heads/main/docs/static/templates/section-template.md |
 | Added `topic/<TYPE>` Make targets to create a topic from its template | [Topic types](/docs/writers-toolkit/structure/topic-types/)                                                         |
+| Added `video-embed` to Shortcodes page. | [Shortcodes](/docs/writers-toolkit/write/shortcodes/)                                                         |
 
 ## January 2025
 

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -1202,7 +1202,7 @@ Use `.mp4` files of 10 MB or smaller.
 The shortcode requires a single parameter, the `src`, to set the source of the image. For this, use the path to the recording file:
 
 ```
-{{</* video-embed src="/media/<path-to-recording/recording.mp4>" */>}}
+{{</* video-embed src="<PATH>" */>}}
 ```
 
 ## Vimeo

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -1194,6 +1194,17 @@ Produces:
 
 {{< translate "docs_feedback_heading" >}}
 
+## Video-embed
+
+The `video-embed` shortcode embeds videos on the page.
+This is the recommended format for short `.mp4` files of 10 MB or smaller.
+
+The shortcode requires a single argument which is the path to the video file in the media folder:
+
+```
+{{</* video-embed src="/media/<path-to-recording/recording.mp4>" */>}}
+```
+
 ## Vimeo
 
 The `vimeo` shortcode embeds videos hosted on vimeo.com.

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -1197,9 +1197,9 @@ Produces:
 ## Video-embed
 
 The `video-embed` shortcode embeds videos on the page.
-This is the recommended format for short `.mp4` files of 10 MB or smaller.
+Use `.mp4` files of 10 MB or smaller.
 
-The shortcode requires a single argument which is the path to the video file in the media folder:
+The shortcode requires a single parameter, the `src`, to set the source of the image. For this, use the path to the recording file:
 
 ```
 {{</* video-embed src="/media/<path-to-recording/recording.mp4>" */>}}


### PR DESCRIPTION
Adding the `video-embed` shortcode to the Shortcodes page for easy access. I always look on this page for all shortcodes and I always have to go over to the Image and media guidelines page to find this shortcode.