### PR TITLE
Remove inline shortcodes

### DIFF
--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/contribute/
   - /docs/writers-toolkit/contribute-documentation/
   - /docs/writers-toolkit/writing-guide/contribute-documentation/
-date: "2022-07-08T16:42:14+01:00"
+date: '2022-07-08T16:42:14+01:00'
 description: Learn how you can contribute to Grafana Labs documentation.
 keywords:
   - contribute
@@ -11,7 +11,7 @@ keywords:
   - edit documentation
   - review documentation
 menuTitle: Contribute
-review_date: "2024-09-03"
+review_date: '2024-09-03'
 title: Contribute to documentation
 weight: 200
 ---
@@ -72,7 +72,7 @@ In that case, you can use the GitHub code navigation to try and find the new loc
 
 If pages don't have a **Suggest an edit** link, the documentation isn't open source.
 Only Grafana Labs employees can update closed source documentation.
-If you're not a Grafana Labs employee, you can still [{{< translate "docs_feedback_report" >}}](#{{< anchorize.inline "docs_feedback_report" >}}{{ anchorize (T (.Get 0)) }}{{< /anchorize.inline >}}).
+If you're not a Grafana Labs employee, you can still [email](mailto:docs@grafana.com).
 
 For example, [Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/) is in the [website repository](https://github.com/grafana/website).
 

--- a/docs/sources/contribute/_index.md
+++ b/docs/sources/contribute/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/writers-toolkit/contribute/
   - /docs/writers-toolkit/contribute-documentation/
   - /docs/writers-toolkit/writing-guide/contribute-documentation/
-date: '2022-07-08T16:42:14+01:00'
+date: "2022-07-08T16:42:14+01:00"
 description: Learn how you can contribute to Grafana Labs documentation.
 keywords:
   - contribute
@@ -11,7 +11,7 @@ keywords:
   - edit documentation
   - review documentation
 menuTitle: Contribute
-review_date: '2024-09-03'
+review_date: "2024-09-03"
 title: Contribute to documentation
 weight: 200
 ---

--- a/docs/sources/introduction/index.md
+++ b/docs/sources/introduction/index.md
@@ -3,13 +3,13 @@ aliases:
   - /docs/writers-toolkit/about-grafana-docs/
   - /docs/writers-toolkit/introduction/
   - /docs/writers-toolkit/writing-guide/about-grafana-docs/
-date: "2022-07-08T16:42:14+01:00"
+date: '2022-07-08T16:42:14+01:00'
 description: Learn about how Grafana Labs manages technical documentation.
 keywords:
   - Grafana
   - documentation
 menuTitle: Introduction
-review_date: "2024-09-04"
+review_date: '2024-09-04'
 title: Introduction to documentation
 weight: 100
 ---
@@ -61,9 +61,9 @@ For more information, refer to the Markdown style guide in [Markdown guide](http
 
 You can contribute content in the following ways:
 
-- [{{< translate "docs_feedback_report" >}}](https://grafana.com/docs/writers-toolkit/contribute/#{{< anchorize.inline "docs_feedback_report" >}}{{ anchorize (T (.Get 0)) }}{{< /anchorize.inline >}})
-- [{{< translate "docs_feedback_suggest" >}}](https://grafana.com/docs/writers-toolkit/contribute/#{{< anchorize.inline "docs_feedback_suggest" / >}})
-- [Develop a new topic](https://grafana.com/docs/writers-toolkit/contribute/#develop-a-new-topic)
+- [Email the Grafana Documentation team](/docs/writers-toolkit/contribute/#email-docsgrafanacom)
+- [Suggest an edit in GitHub](/docs/writers-toolkit/contribute/#suggest-an-edit-in-github)
+- [Develop a new topic](/docs/writers-toolkit/contribute/#develop-a-new-topic)
 
 ## Join the community
 

--- a/docs/sources/introduction/index.md
+++ b/docs/sources/introduction/index.md
@@ -3,13 +3,13 @@ aliases:
   - /docs/writers-toolkit/about-grafana-docs/
   - /docs/writers-toolkit/introduction/
   - /docs/writers-toolkit/writing-guide/about-grafana-docs/
-date: '2022-07-08T16:42:14+01:00'
+date: "2022-07-08T16:42:14+01:00"
 description: Learn about how Grafana Labs manages technical documentation.
 keywords:
   - Grafana
   - documentation
 menuTitle: Introduction
-review_date: '2024-09-04'
+review_date: "2024-09-04"
 title: Introduction to documentation
 weight: 100
 ---
@@ -61,7 +61,7 @@ For more information, refer to the Markdown style guide in [Markdown guide](http
 
 You can contribute content in the following ways:
 
-- [Email the Grafana Documentation team](/docs/writers-toolkit/contribute/#email-docsgrafanacom)
+- [Send an email to the Grafana Documentation team](/docs/writers-toolkit/contribute/#email-docsgrafanacom)
 - [Suggest an edit in GitHub](/docs/writers-toolkit/contribute/#suggest-an-edit-in-github)
 - [Develop a new topic](/docs/writers-toolkit/contribute/#develop-a-new-topic)
 


### PR DESCRIPTION
Inline shortcodes are powerful templating tools and allow source projects to iterate on HTML templates without a PR to the website repository.

However, by accident or malintent, they can be used break the website or expose information.

On the balance of things, the Docs Platform team believes that the risk outweighs the reward and will be disabling the feature.

The team believes it can support the prompt and safe creation of central shortcodes to satisfy the needs of the source projects.
All existing inline shortcodes have already been translated into central shortcodes that everyone can use.

Created-By: reverse-changes
Repository: grafana/writers-toolkit
Website-Pull-Request: https://github.com/grafana/website/pull/24705