### PR TITLE
Add support for workflow dispatch and running on main for documentation CI

### DIFF
--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -44,7 +44,13 @@ jobs:
       image: grafana/vale:latest@sha256:61db326dc6e5df46ff88ca7fe206db5d6c0e69fc43516f5aba8a809dffb9dd0d
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name == 'pull_request'
         with:
+          persist-credentials: false
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 2
           persist-credentials: false
       - uses: ./vale-action
 

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -44,7 +44,7 @@ jobs:
       image: grafana/vale:latest@sha256:61db326dc6e5df46ff88ca7fe206db5d6c0e69fc43516f5aba8a809dffb9dd0d
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         with:
           persist-credentials: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -1,14 +1,12 @@
 name: Documentation CI
 on:
-  push:
-    branches: ["main"]
-    paths: ["docs/sources/**", "vale/**"]
+  push: { branches: [main] }
   pull_request:
     paths: ["docs/sources/**", "vale/**"]
   workflow_dispatch:
 jobs:
   prettier:
-    if: ${{ github.repository == 'grafana/writers-toolkit' }}
+    if: github.repository == 'grafana/writers-toolkit'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -24,7 +22,8 @@ jobs:
             echo 'Not all documentation has been formatted with `prettier`, run `npx prettier -w docs/sources` to resolve'
           fi
   test:
-    if: ${{ github.repository == 'grafana/writers-toolkit' }}
+    if: github.repository == 'grafana/writers-toolkit'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,6 +35,8 @@ jobs:
           website_directory: docs/writers-toolkit
 
   vale:
+    if: github.repository == 'grafana/writers-toolkit'
+
     permissions:
       contents: read
       security-events: write
@@ -55,7 +56,7 @@ jobs:
       - uses: ./vale-action
 
   report-readability:
-    if: ${{ github.repository == 'grafana/writers-toolkit' }}
+    if: github.repository == 'grafana/writers-toolkit' || github.event_name == 'pull_request'
 
     container:
       image: grafana/vale:latest@sha256:55bf7dcba4ceac896b55225084bdb0b27e2e2f70c1398313bee13cb45eb60a95

--- a/vale-action/action.yml
+++ b/vale-action/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Get changed files
-      if: ${{ ! contains(github.event.pull_request.body, '<!-- vale = NO -->') }}
+      if: github.event == pull_request && ! contains(github.event.pull_request.body, '<!-- vale = NO -->')
       id: changed-files
       uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
       with:
@@ -29,7 +29,7 @@ runs:
 
     - name: Vale
       env:
-        FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        FILES: ${{ steps.changed-files.outputs.all_changed_files || inputs.directory }}
         FILTER: --filter=${{ inputs.filter }}
       run: |
         if [ -n "${RUNNER_DEBUG+x}" ]; then

--- a/vale-action/action.yml
+++ b/vale-action/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Get changed files
-      if: github.event == pull_request && ! contains(github.event.pull_request.body, '<!-- vale = NO -->')
+      if: github.event == 'pull_request' && ! contains(github.event.pull_request.body, '<!-- vale = NO -->')
       id: changed-files
       uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
       with:
@@ -28,6 +28,7 @@ runs:
       shell: sh
 
     - name: Vale
+      if: "! contains(github.event.pull_request.body, '<!-- vale = NO -->')"
       env:
         FILES: ${{ steps.changed-files.outputs.all_changed_files || inputs.directory }}
         FILTER: --filter=${{ inputs.filter }}


### PR DESCRIPTION
Now we can report CodeQL issues with the docs (from Vale), it makes sense to track them on `main` so PRs can see if they introduced the issue or if it already existed.

- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
