### PR TITLE
Only keep lines that weren't pre-existing

### DIFF
--- a/vale-action/action.yml
+++ b/vale-action/action.yml
@@ -43,7 +43,8 @@ runs:
 
         (cd /etc/vale && vale sync)
         vale "${FILTER}" --no-exit --output=/etc/vale/sarif.tmpl ${FILES} > vale.sarif
-        /bin/filter-sarif "${OWNER}" "${REPO#${OWNER}/}" "${PR_NUMBER}" vale.sarif
+        /bin/filter-sarif "${OWNER}" "${REPO#${OWNER}/}" "${PR_NUMBER}" vale.sarif > filtered.sarif
+        mv filtered.sarif vale.sarif
       shell: sh
 
     - name: Create annotations from SARIF

--- a/vale/tools/cmd/filter-sarif/main.go
+++ b/vale/tools/cmd/filter-sarif/main.go
@@ -62,14 +62,10 @@ func main() {
 		os.Exit(exit.RuntimeError)
 	}
 
-	filteredData, err := json.MarshalIndent(filtered, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error marshaling filtered SARIF: %v\n", err)
-		os.Exit(exit.RuntimeError)
-	}
-
-	if err := os.WriteFile(args.sarifPath, filteredData, 0o600); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing filtered SARIF: %v\n", err)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(filtered); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding filtered SARIF: %v\n", err)
 		os.Exit(exit.RuntimeError)
 	}
 


### PR DESCRIPTION
Chunks contain additional context can contain linting errors but that isn't part of a contributors patch.

- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
