### PR TITLE
Use docs-platform-team GitHub App for repo workflows

### DIFF
--- a/.github/workflows/dictionaries.yml
+++ b/.github/workflows/dictionaries.yml
@@ -3,12 +3,24 @@ on:
   workflow_dispatch:
 jobs:
   main:
-    if: ${{ github.repository == 'grafana/writers-toolkit' }}
+    if: github.repository == 'grafana/writers-toolkit'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@97c6f45f01d4bca8a3b1acfe397113ce88858a81 # get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            DOCS_PLATFORM_TEAM_APP_ID=docs-platform-team:app-id
+            DOCS_PLATFORM_TEAM_PRIVATE_KEY=docs-platform-team:key
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ env.DOCS_PLATFORM_TEAM_APP_ID }}
+          owner: grafana
+          private-key: ${{ env.DOCS_PLATFORM_TEAM_PRIVATE_KEY }}
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: package.json
@@ -20,7 +32,7 @@ jobs:
       - run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
       - working-directory: vale
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euf -o pipefail
 
@@ -36,6 +48,7 @@ jobs:
             git commit --message 'Update generated Vale files'
           }
 
+          # It's fine to run this even though it depends on committed code because only repository collaborators with write access can trigger the workflow (Grafana Labs employees).
           make -B all
 
           if ! git diff --exit-code; then

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
 jobs:
   prettier:
+    permissions:
+      contents: read
+      id-token: write
     if: ${{ github.repository == 'grafana/writers-toolkit' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,6 @@ jobs:
     if: ${{ github.repository == 'grafana/writers-toolkit' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/writers-toolkit/prettier@4b1248585248751e3b12fd020cf7ac91540ca09c # prettier/v2.0.1
+      - uses: grafana/writers-toolkit/prettier@jdb/2025-04-use-docs-platform-github-app
         with:
           branch: ${{ env.GITHUB_REF }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,6 +1,11 @@
 name: Run `prettier` on a branch
 on:
   workflow_dispatch:
+    inputs:
+      path:
+        default: docs/sources
+        description: Path to run `prettier` on.
+        type: string
 jobs:
   prettier:
     permissions:
@@ -12,3 +17,4 @@ jobs:
       - uses: grafana/writers-toolkit/prettier@jdb/2025-04-use-docs-platform-github-app
         with:
           branch: ${{ env.GITHUB_REF }}
+          path: ${{ inputs.path }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.repository == 'grafana/writers-toolkit' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/writers-toolkit/prettier@jdb/2025-04-use-docs-platform-github-app
+      - uses: grafana/writers-toolkit/prettier@main
         with:
           branch: ${{ env.GITHUB_REF }}
           path: ${{ inputs.path }}

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -22,8 +22,8 @@ runs:
       uses: grafana/shared-workflows/actions/get-vault-secrets@97c6f45f01d4bca8a3b1acfe397113ce88858a81 # get-vault-secrets-v1.0.1
       with:
         repo_secrets: |
-          DOCS_PLATFORM_TEAM_APP_ID=docs-team/docs-platform-team:app-id
-          DOCS_PLATFORM_TEAM_PRIVATE_KEY=docs-team/docs-platform-team:key
+          DOCS_PLATFORM_TEAM_APP_ID=docs-platform-team:app-id
+          DOCS_PLATFORM_TEAM_PRIVATE_KEY=docs-platform-team:key
     - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
       if: inputs.token == ''
       id: app-token

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: Name of branch to checkout and write changes to.
     required: true
   token:
-    default: ${{ github.token }}
+    default: ""
     description: Used to open the PR.
     required: false
 runs:
@@ -15,9 +15,26 @@ runs:
       with:
         persist-credentials: false
         ref: ${{ inputs.branch }}
+        # Use github.token since that can usually always read the repository contents.
+        token: ${{ github.token }}
+    - id: get-secrets
+      if: inputs.token == ''
+      uses: grafana/shared-workflows/actions/get-vault-secrets@97c6f45f01d4bca8a3b1acfe397113ce88858a81 # get-vault-secrets-v1.0.1
+      with:
+        repo_secrets: |
+          DOCS_PLATFORM_TEAM_APP_ID=docs-team/docs-platform-team:app-id
+          DOCS_PLATFORM_TEAM_PRIVATE_KEY=docs-team/docs-platform-team:key
+    - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+      if: inputs.token == ''
+      id: app-token
+      with:
+        app-id: ${{ env.DOCS_PLATFORM_TEAM_APP_ID }}
+        owner: grafana
+        private-key: ${{ env.DOCS_PLATFORM_TEAM_PRIVATE_KEY }}
     - name: Update `make docs` procedure
       env:
-        GH_TOKEN: ${{ github.token }}
+        # Use App token if present because the github.token doesn't trigger other workflows like CI for pull requests.
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: |
         set -euf -o pipefail
 

--- a/prettier/action.yml
+++ b/prettier/action.yml
@@ -4,6 +4,10 @@ inputs:
   branch:
     description: Name of branch to checkout and write changes to.
     required: true
+  path:
+    default: docs/sources
+    description: Path to run `prettier` on.
+    required: false
   token:
     default: ""
     description: Used to open the PR.
@@ -35,6 +39,7 @@ runs:
       env:
         # Use App token if present because the github.token doesn't trigger other workflows like CI for pull requests.
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        PRETTIER_PATH: ${{ inputs.path }}
       run: |
         set -euf -o pipefail
 
@@ -50,7 +55,7 @@ runs:
           git commit --message 'Run `prettier`'
         }
 
-        npx prettier -w .
+        npx prettier -w "${PRETTIER_PATH}"
 
         if ! git diff --exit-code; then
           commit

--- a/vale/Grafana/styles/Grafana/Simple.yml
+++ b/vale/Grafana/styles/Grafana/Simple.yml
@@ -8,7 +8,7 @@ message: |
 
   Try eliminating this word from the sentence because usually you can convey the same meaning without it.
 tokens:
-  - 'easy(?! to understand)'
+  - "easy(?! to understand)"
   - simple
   - simply
 exceptions:


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

Prettier changes tested with `gh workflow run prettier.yml --ref jdb/2025-04-use-docs-platform-github-app --json <<<'{ "path": "vale" }'` when the branch pointed at [`a86266d` (#1145)](https://github.com/grafana/writers-toolkit/pull/1145/commits/a86266deb4c8a4873ff21476650b311fa754016c).



- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
