### PR TITLE
[DOC] Add links to heading guidelines

### DIFF
--- a/docs/sources/structure/topic-types/task/index.md
+++ b/docs/sources/structure/topic-types/task/index.md
@@ -21,7 +21,7 @@ Task topics include numbered steps that describe how to achieve an outcome.
 
 A _task_ topic includes the following elements:
 
-- **Topic title:** Write a task topic title that combines a verb and an object.
+- **Topic title:** Write a task topic title that combines a verb and an object. The verb should describe the action completed by the task, for example, "Configure metrics-generator." Refer to [Headings and titles](https://developers.google.com/style/headings) in the [Google developer documentation style guide](https://developers.google.com/style/) for more information.
 
 - **Introduction:** Provide an introduction that explains why the end user should care about the task.
 

--- a/docs/sources/write/image-guidelines/index.md
+++ b/docs/sources/write/image-guidelines/index.md
@@ -141,7 +141,7 @@ Consult the following guidelines when you create screenshots:
   - Take screenshots on your highest resolution screen. For Mac users, this is typically your laptop screen.
   - Non-Mac users: Take screenshots at twice your max eventual max-width setting to accommodate high resolution screens. If you need to make a screenshot area bigger to accommodate this requirement, use pinch and zoom to double the pixel size. (Macs already take screenshots at 2x DPI).
   - Review screenshots on your highest resolution screen for an accurate indication of how they look. _Good screenshots can often look bad on lower resolution screens._ For Mac users, this is typically your laptop screen.
-- **Scope**: Limit the screenshot to just the portion of the user interface that shows the action, and enough surrounding detail to help the user locate the item. Avoid including elements that may change, such as the navigation sidebar. 
+- **Scope**: Limit the screenshot to just the portion of the user interface that shows the action, and enough surrounding detail to help the user locate the item. Avoid including elements that may change, such as the navigation sidebar.
 - **Annotations**: To annotate a screenshot, use red, hexadecimal color `FF0000`, arrows and boxes.
 - **File name**: Use the naming convention documented in [Media asset file naming conventions](#media-asset-file-naming-conventions).
 - **Personal identifiable information (PII)**: Make sure to mask, modify, or remove any PII such as passwords, logins, account details, or other information that could compromise security.

--- a/docs/sources/write/style-guide/capitalization-punctuation/index.md
+++ b/docs/sources/write/style-guide/capitalization-punctuation/index.md
@@ -20,6 +20,8 @@ This section includes capitalization and punctuation guidelines.
 
 Write headings in sentence case.
 
+Refer to [Headings and titles](https://developers.google.com/style/headings) in the [Google developer documentation style guide](https://developers.google.com/style/) for more information.
+
 Consult the following capitalization guidelines when you write.
 
 ### Sentence case

--- a/docs/sources/write/style-guide/voice-tone-guidelines/index.md
+++ b/docs/sources/write/style-guide/voice-tone-guidelines/index.md
@@ -67,7 +67,7 @@ It's important to Grafana Labs that users feel confident about their actions and
 
 Don't just teach people how to perform an action, but also why they should.
 
-### Motivation
+## Motivation
 
 <!-- vale Grafana.GoogleWill = NO -->
 <!-- This is talking about the future next steps -->

--- a/docs/sources/write/style-guide/voice-tone-guidelines/index.md
+++ b/docs/sources/write/style-guide/voice-tone-guidelines/index.md
@@ -25,13 +25,13 @@ The tone you choose reflects the urgency of your message and can therefore chang
 
 Consult the following voice and tone guidelines when you write technical documentation.
 
-### Project confidence
+## Project confidence
 
 You know the subject matter better than anyone.
 Let your style reflect your expertise.
 Write in an authoritative tone to evoke confidence in your reader.
 
-### Be conversational
+## Be conversational
 
 <!-- vale Grafana.Simple = NO -->
 
@@ -41,7 +41,7 @@ Keep your language simple and straightforward.
 
 <!-- vale Grafana.Simple = YES -->
 
-### Tone
+## Tone
 
 A casual tone is accepted in UI copy and supporting material compared to traditional business writing.
 
@@ -49,12 +49,18 @@ As long as they allow for shorter sentences, you can use the words _and_, _but_,
 
 Use contractions like _isn't_ for _is not_ to help to convey an informal tone.
 
-### Task completion
+## Task completion
 
 Provide the user with just enough information to complete a task.
 Inform the user that something has happened as expected once the task is completed.
 
-### Learning
+In headings for tasks, use a verb that clearly describes the action completed by the task.
+Avoid using gerunds in headings.
+For example, use "Configure metrics-generator" as a heading instead of "Configuring metrics-generator".
+
+Refer to [Headings and titles](https://developers.google.com/style/headings) in the [Google developer documentation style guide](https://developers.google.com/style/) for more information.
+
+## Learning
 
 There are times when it's helpful to explain or educate users more.
 It's important to Grafana Labs that users feel confident about their actions and Grafana Labs' product capabilities.


### PR DESCRIPTION
Add a link to the Google developer documentation style guide to the headings section and add some additional guidance to not use gerunds in headings. 

- [X] I've used a relevant pull request (PR) title.
- [X] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
