### PR TITLE
Fix `docs/learning-journeys` example rendering

### DIFF
--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -509,7 +509,7 @@ This is rendered after the ignore.
 
 ## Docs/learning-journeys
 
-The `docs/learning-journeys` shortcode produces a note admonition with the preferred copy for linking to a Grafana Learning Journey.
+The `docs/learning-journeys` shortcode produces a call to action (CTA) that links to a Grafana Learning Journey.
 
 | Parameter | Description                                | Required |
 | --------- | ------------------------------------------ | -------- |
@@ -594,7 +594,7 @@ Display only paths with the `enterprise` tag for the `grafana` data specificatio
 
 ## Docs/play
 
-The `docs/play` shortcode produces a note admonition with the preferred copy for linking to a Grafana Play dashboard.
+The `docs/play` shortcode produces a call to action (CTA) that links to a Grafana Play dashboard.
 
 | Parameter | Description                              | Required |
 | --------- | ---------------------------------------- | -------- |

--- a/docs/sources/write/shortcodes/index.md
+++ b/docs/sources/write/shortcodes/index.md
@@ -519,7 +519,7 @@ The `docs/learning-journeys` shortcode produces a note admonition with the prefe
 ### Example
 
 ```markdown
-{{< docs/learning-journeys title="Explore data using Metrics Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-metrics/" >}}
+{{</* docs/learning-journeys title="Explore data using Metrics Drilldown" url="https://grafana.com/docs/learning-journeys/drilldown-metrics/" */>}}
 ```
 
 Produces:


### PR DESCRIPTION
Without the comment syntax, Hugo renders the shortcode rather than the text representing the shortcode in the source material.

Also:

[Update CTA shortcodes copy to more accurately describe the output](https://github.com/grafana/writers-toolkit/pull/1193/commits/154d734a94677a8391325568d45d346e5c7edc4d) 
154d734
They used to be admonitions, now they are CTAs