### PR TITLE
Refactor documentation CI into reusable workflow

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,84 @@
+name: Documentation CI
+description: |
+  This action provides consistent steps for documentation CI.
+
+  All steps require the `contents: read` permission
+
+  To use the Vale step, you'll need the following additional permissions:
+
+  ```yaml
+  checks: write
+  ```
+on:
+  workflow_call:
+    inputs:
+      build:
+        default: false
+        description: Whether to test a website build.
+        type: boolean
+      build-website-directory:
+        default: content/docs/test-build
+        description: Directory to mount documentation for the build job.
+
+      prettier:
+        default: false
+        description: Whether to enforce prettier formatting.
+        type: boolean
+
+      vale:
+        default: false
+        description: Whether to run the Vale linter.
+        type: boolean
+jobs:
+  prettier:
+    if: inputs.prettier
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+      - run: |
+          npm install --no-save prettier
+          npx prettier -w docs/sources
+          if ! git diff --exit-code; then
+            echo 'Not all documentation has been formatted with `prettier`, run `npx prettier -w docs/sources` and commit the result to resolve the issue.'
+          fi
+  build:
+    if: inputs.build
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Build website
+        uses: grafana/writers-toolkit/build-website@44d8e2b29fbbdba5c3614ddcfc29be47e5f9e61c # build-website/v1
+        with:
+          website_directory: ${{ inputs.build-website-directory }}
+
+  vale:
+    if: inputs.vale
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    container:
+      image: grafana/vale:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - uses: grafana/writers-toolkit/vale-action@f49dd90f007967990095ac2d18c5bdf37b412a5f # vale-action/v1.4.5

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,10 +4,17 @@ description: |
 
   All steps require the `contents: read` permission
 
-  To use the Vale step, you'll need the following additional permissions:
+
+  To use the build step, you'll need the following additional permissions:
 
   ```yaml
   checks: write
+  ```
+
+  To use the Vale step, you'll need the following additional permissions:
+
+  ```yaml
+  security-events: write
   ```
 on:
   workflow_call:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -19,6 +19,7 @@ on:
       build-website-directory:
         default: content/docs/test-build
         description: Directory to mount documentation for the build job.
+        type: string
 
       prettier:
         default: false

--- a/.github/workflows/validate-documentation-inverse.yml
+++ b/.github/workflows/validate-documentation-inverse.yml
@@ -7,23 +7,11 @@ on:
     paths-ignore: ["docs/sources/**", "vale/**"]
 
 jobs:
-  doc-validator:
-    runs-on: "ubuntu-latest"
-    steps:
-      - run: echo 'No build required'
-  prettier:
-    runs-on: "ubuntu-latest"
-    steps:
-      - run: echo 'No build required'
-  vale:
+  ci: 
     runs-on: "ubuntu-latest"
     steps:
       - run: echo 'No build required'
   report-readability:
-    runs-on: "ubuntu-latest"
-    steps:
-      - run: echo 'No build required'
-  test:
     runs-on: "ubuntu-latest"
     steps:
       - run: echo 'No build required'

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      security-events: write
     uses: ./.github/workflows/docs-ci.yml
     with:
       build: true

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -10,18 +10,15 @@ on:
 
 jobs:
   ci:
-    if: github.repository == 'grafana/writers-toolkit'
     permissions:
       contents: read
       checks: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/docs-ci.yml
-        with:
-          build: true
-          build-website-directory: content/docs/writers-toolkit
-          prettier: true
-          vale: true
+    uses: ./.github/workflows/docs-ci.yml
+    with:
+      build: true
+      build-website-directory: content/docs/writers-toolkit
+      prettier: true
+      vale: true
 
   report-readability:
     if: github.repository == 'grafana/writers-toolkit' || github.event_name == 'pull_request'

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -9,58 +9,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  prettier:
-    if: github.repository == 'grafana/writers-toolkit'
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-      - run: |
-          npm install --no-save prettier
-          npx prettier -w docs/sources
-          if ! git diff --exit-code; then
-            echo 'Not all documentation has been formatted with `prettier`, run `npx prettier -w docs/sources` to resolve'
-          fi
-  test:
+  ci:
     if: github.repository == 'grafana/writers-toolkit'
     permissions:
       contents: read
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/workflows/docs-ci.yml
         with:
-          persist-credentials: false
-      - name: Build website
-        uses: ./build-website
-        with:
-          website_directory: docs/writers-toolkit
-
-  vale:
-    if: github.repository == 'grafana/writers-toolkit'
-    permissions:
-      contents: read
-      security-events: write
-    runs-on: ubuntu-latest
-    container:
-      image: grafana/vale:latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-        with:
-          persist-credentials: false
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name == 'push'
-        with:
-          fetch-depth: 2
-          persist-credentials: false
-      - uses: ./vale-action
+          build: true
+          build-website-directory: content/docs/writers-toolkit
+          prettier: true
+          vale: true
 
   report-readability:
     if: github.repository == 'grafana/writers-toolkit' || github.event_name == 'pull_request'

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -39,5 +39,3 @@ If it's your first time using the guide, start with the [Get started](https://gr
 
 Writers' Toolkit is open source and available at [`grafana/writers-toolkit`](https://github.com/grafana/writers-toolkit).
 If you have questions, or feedback on how to improve this documentation, [open an issue](https://github.com/grafana/writers-toolkit/issues/new) and help make this an even better resource.
-
-test1

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -19,7 +19,7 @@ keywords:
   - style guide
   - Grafana
   - documentation
-review_date: "2024-09-03"
+review_date: "2025-06-12"
 title: Writers' Toolkit
 ---
 


### PR DESCRIPTION
Then we can use the same CI in other repos.


- https://github.com/grafana/writers-toolkit/actions/runs/15605390018/job/43953571237?pr=1194
- https://github.com/grafana/writers-toolkit/actions/runs/15605390018/job/43953571239?pr=1194
- https://github.com/grafana/writers-toolkit/actions/runs/15605390018/job/43953571288?pr=1194

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
