### PR TITLE
Add learning journey instructions

### DIFF
--- a/.github/instructions/learning-journey/_index/frontmatter.yaml
+++ b/.github/instructions/learning-journey/_index/frontmatter.yaml
@@ -1,7 +1,7 @@
 ---
 # Required fields – must be present in all learning journey _index.md files
 
-# Clear, goal-oriented title that matches the H1 heading in the content
+# Clear, goal-oriented title that presents a comprehensive, often multi-stage experience that guides users through a broader topic or set of related, connected technologies
 # Example: "Monitor Linux servers with Grafana Alloy"
 title: "<JOURNEY_TITLE>"
 
@@ -73,7 +73,7 @@ cta:
 # - Full title: "Monitor collector health using Grafana Fleet Management" → menuTitle: "Monitor collector health"
 menuTitle: "<SHORT_MENU_TITLE>"
 
-# SEO keywords for search optimization (3-5 relevant keywords)
+# Keywords for optimization (3 to 5 relevant keywords)
 keywords:
   - <KEYWORD_1> # Focus on main topics and products
   - <KEYWORD_2>

--- a/.github/instructions/learning-journey/_index/frontmatter.yaml
+++ b/.github/instructions/learning-journey/_index/frontmatter.yaml
@@ -1,0 +1,119 @@
+---
+# Required fields – must be present in all learning journey _index.md files
+
+# Clear, goal-oriented title that matches the H1 heading in the content
+# Example: "Monitor Linux servers with Grafana Alloy"
+title: "<JOURNEY_TITLE>"
+
+# Brief description of what users will achieve in this learning journey
+# Pattern: "Welcome to the [Grafana/specific] learning journey that [shows/teaches/provides] [action/outcome]"
+# Examples:
+# - "Welcome to the Grafana learning journey that shows you how to use Logs Drilldown to explore your logs and provide insight into troubleshooting."
+# - "Learn how to monitor a Kubernetes cluster in Grafana Cloud."
+# - "Welcome to the Grafana learning journey that provides the best practice for configuring Alloy to send logs to Grafana Cloud."
+description: "<JOURNEY_DESCRIPTION>"
+
+# Ordering weight for navigation (use increments of 100)
+# Orders learning journeys on the index and navigation
+weight: <WEIGHT_NUMBER>
+
+# Learning journey metadata
+journey:
+  # Skill level for the target audience
+  skill: <SKILL_LEVEL> # Options: Beginner, Intermediate, Advanced
+  # Source type for the journey content
+  source: "<CONTENT_SOURCE>" # Example: "Docs & blog posts"
+  # Journey logo configuration
+  logo:
+    # Path to logo image file
+    src: <LOGO_PATH> # Example: /static/img/menu/alloy-icon.svg
+    # Background color for the logo (hex color code)
+    background: "<BACKGROUND_COLOR>" # Example: '#0068FF'
+    # Logo width in pixels
+    width: <LOGO_WIDTH> # Example: 46
+    # Logo height in pixels
+    height: <LOGO_HEIGHT> # Example: 55
+
+# Step number (always 1 for _index.md files)
+step: 1
+
+# Layout template for learning journey pages
+layout: single-journey
+
+# Cascade configuration applies to all pages in this journey
+cascade:
+  # Layout template inherited by all journey step pages
+  layout: single-journey
+
+# Call-to-action button configuration
+# Pattern: CTAs create engagement and guide users to the next action
+# For _index.md files, always use type "start" to begin the learning journey
+# Standard values: title: "Are you ready?" and cta_text: "Let's go!" are most common
+cta:
+  # CTA type for the journey start page – always "start" for _index.md files
+  type: start
+  # CTA section title text – appears above the button
+  title: "<CTA_TITLE>" # Common: "Are you ready?"
+  # CTA button text – the clickable button text
+  cta_text: "<CTA_BUTTON_TEXT>" # Common: "Let's go!"
+
+# Optional fields – include only when needed
+
+# Shorter navigation title when the main title is too long for menus
+# Pattern: Use when the full title is over 50 characters or contains redundant words for navigation
+# Guidelines:
+# 1. Remove "learning journey" or similar meta-language
+# 2. Keep the core action verb and main product/technology
+# 3. Aim for 20-35 characters when possible
+# 4. Preserve the essential meaning while being concise
+# Examples:
+# - Full title: "Monitor Linux servers with Grafana Alloy" → menuTitle: "Monitor a Linux server"
+# - Full title: "Explore logs using Logs Drilldown" → menuTitle: "Logs Drilldown"
+# - Full title: "Use Traces Drilldown to identify high latency service requests" → menuTitle: "Identify high latency service requests"
+# - Full title: "Monitor collector health using Grafana Fleet Management" → menuTitle: "Monitor collector health"
+menuTitle: "<SHORT_MENU_TITLE>"
+
+# SEO keywords for search optimization (3-5 relevant keywords)
+keywords:
+  - <KEYWORD_1> # Focus on main topics and products
+  - <KEYWORD_2>
+  - <KEYWORD_3>
+  - <KEYWORD_4>
+  - <KEYWORD_5>
+
+# Additional labels for categorization
+labels:
+  # Difficulty level label
+  difficulty: "<DIFFICULTY_LABEL>" # Options: beginner, intermediate, advanced
+  # Time estimate label
+  time: "<TIME_ESTIMATE>" # Example: "10 minutes"
+
+# URL aliases for renamed or moved content (maintains old URL access)
+aliases:
+  - /<OLD_PATH_1>/
+  - /<OLD_PATH_2>/
+
+# Related journeys section for prerequisites or complementary content
+# Use when users need data/setup from other journeys or when suggesting logical next steps
+# Pattern: Explains why these journeys are related and when users should consider them
+related_journeys:
+  # Section title for related journeys
+  title: "<RELATED_SECTION_TITLE>" # Common: "Related journeys"
+  # Contextual explanation of why these journeys are related
+  # Patterns:
+  # 1. Prerequisites: "[Journey] expects [data type] to be available. If you don't yet have [data type] flowing into Grafana Cloud, any of these related journeys will help you."
+  # 2. Recommendations: "Consider taking the following journeys before you start this journey."
+  # 3. Dependencies: "This journey expects [prerequisite] to be installed. If you don't yet have [prerequisite] installed, any of these related journeys will help you."
+  # Examples:
+  # - "Logs Drilldown expects logs to be available. If you don't yet have logs flowing into Grafana Cloud, any of these related journeys will help you."
+  # - "Consider taking the following journeys before you start this journey."
+  # - "This journey expects Grafana Alloy to be installed. If you don't yet have Grafana Alloy installed, any of these related journeys will help you."
+  heading: "<RELATED_JOURNEYS_CONTEXT>"
+  # List of related journey links
+  items:
+    - title: "<RELATED_JOURNEY_1_TITLE>"
+      link: "<RELATED_JOURNEY_1_LINK>"
+    - title: "<RELATED_JOURNEY_2_TITLE>"
+      link: "<RELATED_JOURNEY_2_LINK>"
+---
+

--- a/.github/instructions/learning-journey/_index/markdown.md
+++ b/.github/instructions/learning-journey/_index/markdown.md
@@ -1,0 +1,280 @@
+# Learning journey content template
+
+This template gives the standard content structure and language patterns for learning journey `_index.md` files. The template is based on analysis of existing journeys.
+
+## Required sections and order
+
+1. **YAML front matter** (refer to the front matter template)
+1. **H1 heading** (must match the `title` in front matter)
+1. **Introduction paragraph** (2-3 sentences about the goal and key concepts)
+1. **"Here's what to expect" admonition**
+1. **Before you begin** (prerequisites list)
+1. **Troubleshooting** (common issues and solutions)
+1. **More to explore** (related resources and next steps)
+
+## Content structure and order
+
+### 1. H1 heading
+
+Use this pattern for the H1 heading:
+
+```markdown
+# [Action verb] [technology/goal] [with/using] [Grafana product]
+```
+
+Pattern examples:
+
+- `# Explore logs using Logs Drilldown`
+- `# Monitor Linux servers with Grafana Alloy`
+- `# Visualize CSV data using the Infinity data source`
+- `# Use Traces Drilldown to identify high latency service requests`
+- `# Connect to a Prometheus data source in Grafana Cloud`
+
+Guidelines:
+
+- The H1 must match the YAML front matter `title` exactly
+- Use action verbs: "Monitor", "Explore", "Visualize", "Send", "Create", "Connect", "Use", "Set up", "Migrate"
+- Include the primary technology and Grafana product
+- Keep under 60 characters for SEO
+- Use verb phrases that describe the main goal
+- Example headings: "Monitor Linux servers with Grafana Alloy", "Set up alerting with Grafana", "Migrate from Prometheus to Grafana Cloud"
+
+### 2. Welcome statement and introduction paragraph
+
+Start with a welcome statement and a short introduction:
+
+```markdown
+Welcome to the [specific description] learning journey [that shows/teaches/provides] [main goal].
+```
+
+Standard welcome phrases:
+
+- `Welcome to the Grafana learning journey that shows you how to...`
+- `Welcome to the Grafana learning journey that teaches you...`
+- `Welcome to the Grafana learning journey that provides...`
+- `Welcome to the [specific feature] learning journey.`
+
+Introduction structure:
+
+1. Welcome statement (required) – Start with "Welcome to the [journey name] learning journey"
+1. Primary goal statement – State the main goal of the learning journey in the second sentence
+1. Product context – Mention the main Grafana products used and their purpose
+1. Value proposition – Give context about the technology (what it is, how it works)
+1. User accomplishment – Briefly describe what users will learn or accomplish
+1. Outcome reference – End with a reference to an example image showing the expected outcome
+
+Example patterns:
+
+```markdown
+Welcome to the Explore logs using Logs Drilldown learning journey. [Feature name] is a feature designed to [core purpose] by providing [key benefit]. It lets you [specific capability] without the need for [what it replaces], making it accessible to [target audience].
+
+[Product name] is a feature exclusive to [Grafana product]. [Product] is a [technical description] inspired by [comparison]. [Product] differs from [other technology] by [key differentiator].
+
+The [description] image below shows [specific content example].
+```
+
+### 3. Product context section (when applicable)
+
+- Give background information about the main technology or product.
+- Explain how it fits into the broader Grafana ecosystem.
+- Include links to relevant product documentation using inline links.
+- Use technical details that help users understand the value proposition.
+
+Pattern for product explanations:
+
+```markdown
+[Product name] is a [technical description]. [Product] is [architecture description] inspired by [reference technology]. [Product] differs from [comparison] by [key difference], and [additional differentiator].
+
+[Additional technical context explaining how it works or fits in the ecosystem.]
+```
+
+Examples:
+
+- "Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. Loki differs from Prometheus by focusing on logs instead of metrics, and collecting logs via push, instead of pull."
+- "Prometheus is an open source systems monitoring and alerting toolkit that captures metrics as time series data and optional key-value pairs called labels."
+
+### 4. Example image and caption
+
+- Include a descriptive image showing the end result or main interface.
+- Use detailed alt text that explains what the image shows.
+- Place the image after the introduction and context paragraphs.
+- Reference the image in the text with phrases like "The image below shows" or "The following image displays".
+
+Image reference pattern:
+
+```markdown
+The [description] image below [shows/displays] [specific content].
+
+![Descriptive alt text explaining what the image shows](/media/docs/learning-journey/[journey-folder]/[image-name].png)
+```
+
+Alt text patterns:
+
+- `Example [feature] user interface`
+- `Example [feature] visualization`
+- `Image that shows [specific data] in [format] format`
+- `Example [system type] node overview dashboard`
+
+### 5. "Here's what to expect" section (required)
+
+- Always include this section.
+- Use the `{{< docs/box >}}` and `{{< docs/icon-heading >}}` shortcodes. - Always use the heading format: `{{< docs/icon-heading heading="## Here's what to expect" >}}`.
+- Include 3-5 bullet points describing the main learning outcomes.
+- Use action-oriented language starting with verbs.
+- Order items logically from basic setup to advanced features.
+- Focus on specific, measurable outcomes users will achieve.
+
+Exact structure:
+
+```markdown
+{{< docs/box >}}
+
+{{< docs/icon-heading heading="## Here's what to expect" >}}
+
+When you complete this journey, you'll be able to:
+
+- [Action verb] [specific outcome]
+- [Action verb] [specific outcome]
+- [Action verb] [specific outcome]
+- [Action verb] [specific outcome]
+
+{{< /docs/box >}}
+```
+
+Action verb patterns:
+
+- Navigate to [feature/location]
+- Search for and filter [specific items]
+- Learn how to [specific skill]
+- Understand the [concept/value]
+- Install [product] and [configuration action]
+- Configure [specific setting]
+- Create [specific artifact]
+- Use [tool] to [specific purpose]
+- Verify that [outcome] appear in [location]
+- Build a dashboard [with specific content]
+- Interpret [interface] so that you can [goal]
+
+Outcome examples:
+
+- "Navigate to Logs Drilldown"
+- "Search for and filter specific logs you want to investigate"
+- "Learn how to drill down into a log and investigate related logs"
+- "Add a log visualization to a dashboard"
+- "Understand the value of observability and the advantages of Grafana [Product]"
+- "Use pre-built dashboards and alerts to identify and troubleshoot problems in your environment"
+
+### 6. Troubleshooting section (required)
+
+- Always include this section.
+- Always use the exact heading "## Troubleshooting".
+- Include the standardized opening text: "If you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away."
+- Don't include any specific issues here; mention them on the relevant step pages in the front matter.
+
+Exact text:
+
+```markdown
+## Troubleshooting
+
+If you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.
+```
+
+### 7. More to explore section (required)
+
+- Always include this section.
+- Always use the exact heading "## More to explore".
+- Include the standardized opening text: "We understand you might want to explore other capabilities not strictly on this path.
+- We'll provide you opportunities where it makes sense."
+- Link to related learning journeys using relative paths.
+- Reference relevant product documentation with external links.
+- Suggest logical next steps or advanced topics.
+- Order items from most relevant to general resources.
+- Use consistent link formatting for both internal and external links.
+
+Exact text:
+
+```markdown
+## More to explore
+
+We understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense.
+```
+
+### 8. Before you begin section (required)
+
+- Always include this section.
+- Always use the exact heading "## Before you begin".
+- Always start with the phrase "Before you [action verb], ensure that you have:" or "Before you [action verb], you must:".
+- List prerequisites in order of importance: account access, technical requirements, knowledge prerequisites.
+- Use the exact text for Grafana Cloud account creation (often the first prerequisite): `- A Grafana Cloud account. To create an account, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).`
+- Include specific version requirements when relevant (for example, "Ubuntu 20.04 or later recommended").
+- Include data availability requirements (metrics, logs, traces flowing into Grafana Cloud).
+- Add familiarity requirements that help users succeed. Include shared snippets for common prerequisites using `{{< shared-snippet >}}` shortcode when available.
+
+Opening patterns:
+
+```markdown
+Before you [action verb], ensure that you have:
+Before you [action verb], you must:
+```
+
+Action verbs used:
+
+- "use [Feature name]"
+- "send [data type] to [destination]"
+- "connect to [data source type]"
+- "add and configure [plugin/component]"
+- "visualize [data type] in a Grafana Cloud dashboard"
+- "monitor [system type] using [tool]"
+
+Standard prerequisites order:
+
+1. **Grafana Cloud account (always first when applicable):**
+
+```markdown
+- A Grafana Cloud account. To create an account, refer to [Grafana Cloud](https://grafana.com/signup/cloud/connect-account).
+```
+
+1. **Technical requirements:**
+
+- System access and permissions
+- Software installation requirements
+- Data availability requirements
+- Network/connectivity requirements
+
+1. **Knowledge prerequisites:**
+
+- Familiarity with technologies
+- Understanding of concepts
+- Experience with tools
+
+Common prerequisites patterns:
+
+**Data availability:**
+
+```markdown
+- [Data type] up and running and connected as a data source, whether it's locally installed or using [Grafana Cloud Product], provided by Grafana Cloud.
+- [Data type] ingested into [Product] using agents such as [Grafana Alloy](/docs/[product]/latest/send-data/alloy/), [OpenTelemetry Collector](/docs/[product]/latest/send-data/otel/), or other [third-party clients](/docs/[product]/latest/send-data/#third-party-clients).
+```
+
+**Experience requirements:**
+
+```markdown
+- Experience working with [Technology] and understand its basic setup and operation.
+- Basic familiarity with [Product], [Query language], and basic Grafana navigation.
+- A familiarity with the [data type] you plan to [action]. Understanding what these [items] measure or represent will help you [specific benefit].
+```
+
+**Access requirements:**
+
+```markdown
+- Access to the machine on which [Software] is installed.
+- [Specific permission level] permissions.
+- Access to your [data type] that does not contain private information.
+```
+
+**Related journey prerequisites:**
+
+```markdown
+- [Created a private connection to a data source](/docs/learning-journeys/private-data-source-connect) and the PDC agent is running.
+  - While not required, setting up a private data source connection is highly recommended when you use Grafana Cloud to connect to a data source.
+```

--- a/.github/instructions/learning-journey/learning-journey.instructions.md
+++ b/.github/instructions/learning-journey/learning-journey.instructions.md
@@ -1,0 +1,151 @@
+---
+applyTo: "learning-journeys/**/*.md"
+---
+
+# Copilot instructions: Learning journeys
+
+A learning journey is a multi-step tutorial that helps users achieve a specific product goal using Grafana Labs products.
+Each learning journey is a folder in `learning-journeys/`, with an `_index.md` file for the journey overview and an `index.md` file in each subfolder for individual steps.
+
+## Folder and file structure
+
+- Each learning journey is a folder under `learning-journeys/`.
+- The journey overview is in `_index.md` at the root of the journey folder.
+- Each step is a subfolder with its own `index.md`.
+- Use kebab-case for folder names (for example, `monitor-linux-servers`).
+- Use descriptive step folder names (for example, `install-alloy`, `configure-grafana`).
+
+Example:
+
+```
+learning-journeys/
+  monitor-linux-servers/
+    _index.md
+    install-alloy/
+      index.md
+    configure-grafana/
+      index.md
+    create-dashboard/
+      index.md
+```
+
+## Steps
+
+### Naming patterns
+
+Step folder names use descriptive kebab-case that indicates the action or topic:
+
+**Business value and introduction steps:**
+
+- `business-value` / `business-value-[product]` - Explains why use the product
+- `advantages` / `advantages-[product]` - Lists product benefits
+- `value-of-[feature]` - Explains feature value
+
+**Installation and setup steps:**
+
+- `install-[product]` - Install software or components
+- `add-data-source` - Add data source configuration
+- `create-token` – Generate authentication tokens
+- `config-authentication` / `enter-authentication-credentials` – Set up authentication
+
+**Configuration and data steps:**
+
+- `select-[item]` / `choose-[item]` – Make configuration choices
+- `search-[item]` / `search-and-filter` – Find and filter data
+- `send-[data-type]` – Configure data sending
+- `verify-[item]` – Confirm setup works
+
+**Build and test steps:**
+
+- `build-[component]` / `create-[artifact]` – Build applications or components
+- `run-[application]` / `execute-[script]` – Run applications or execute scripts
+- `test-[functionality]` / `validate-[setup]` – Test functionality or validate configuration
+- `deploy-[service]` / `publish-[artifact]` – Deploy services or publish artifacts
+
+**Analysis and exploration steps:**
+
+- `analyze-data` / `investigate-data` – Examine collected data
+- `view-[item]` – Display specific views or lists
+- `open-[location]` / `open-in-explore` – Navigate to analysis tools
+
+**Dashboard and visualization steps:**
+
+- `add-visualization` / `create-dashboard` – Build visualizations
+- `write-query` – Create queries for data
+- `add-to-dashboard` / `add-[item]-dashboard` – Save to dashboards
+- `time-range-refresh` – Configure time settings
+- `save-dashboard` – Save dashboard configurations
+
+**Completion steps:**
+
+- `end-journey` / `destination-reached` – Journey conclusion
+
+### Ordering patterns
+
+Steps follow logical progression patterns:
+
+**Infrastructure monitoring journeys:**
+
+1. Business value/case for observability (weight: 100)
+2. Product advantages (weight: 200)
+3. Installation/setup (weight: 300-400)
+4. Configuration (weight: 500-600)
+5. Verification (weight: 700)
+6. Usage/analysis (weight: 800)
+7. Conclusion (weight: 900)
+
+**Data exploration journeys:**
+
+1. Business value (weight: 100)
+2. Navigation/access (weight: 200)
+3. Search and filter (weight: 300)
+4. Analysis/investigation (weight: 400-500)
+5. Open in Explore (weight: 600)
+6. Add to dashboard (weight: 700)
+7. Conclusion (weight: 800)
+
+**Visualization journeys:**
+
+1. Business value (weight: 100)
+2. Create dashboard (weight: 300)
+3. Write query (weight: 400)
+4. Configure time/refresh (weight: 500)
+5. Save dashboard (weight: 600)
+6. Conclusion (weight: 700)
+
+**Data source connection journeys:**
+
+1. Business value (weight: 100)
+2. Product advantages (weight: 200)
+3. Install plugin (weight: 300)
+4. Add data source (weight: 400)
+5. Configure authentication (weight: 500)
+6. Test connection (weight: 600-700)
+7. Build dashboard (weight: 800)
+8. Conclusion (weight: 900)
+
+### Weight increments
+
+- Use increments of 100 for weight values
+- Start at weight 100 for the first step after the overview
+- Allow gaps for future insertion of steps
+- Conclusion steps typically have the highest weight
+
+## Shared Content Integration
+
+**Guidelines:**
+
+- Use `{{< shared-snippet >}}` shortcodes for reusable content blocks
+- Use a shared snippet shortcode to reuse and embed eixistin documentation snippets
+- Include the code snippet, and if the snippet came from an attached context file,
+  also include the shared snippet shortcode linking to the file
+- Reference shared prerequisites from other documentation sections
+- Include `{{% shared-snippet %}}` for content that needs to be processed as markdown
+
+**Examples:**
+
+```markdown
+{{< shared-snippet path="/docs/grafana-cloud/monitor-infrastructure/integrations/get-started.md" id="grafana-cloud-setup" >}}
+
+{{% shared-snippet path="/docs/fleet-management/next/_index.md" id="flt-mgt-lj-intro" %}}
+```

--- a/.github/instructions/learning-journey/step/frontmatter.yaml
+++ b/.github/instructions/learning-journey/step/frontmatter.yaml
@@ -1,0 +1,91 @@
+---
+# Required fields
+
+# Short navigation menu title – keep under 20 characters for readability
+# Examples: "Add to dashboard", "Create dashboard", "Install data source", "Value of Logs Drilldown"
+menuTitle: <MENU_TITLE>
+
+# Full page title – can be longer and more descriptive than menuTitle
+# Should match the h1 heading in the content. Examples:
+# "Add Logs Drilldown visualization to a dashboard"
+# "The value of Grafana Alloy"
+# "Install the Infinity data source plugin"
+title: <PAGE_TITLE>
+
+# Brief description explaining what the page covers or teaches (1-2 sentences)
+# Start with an action word like "Learn", "Understand", or "Configure"
+# Examples: "Learn how to save your query and add it to a dashboard for ongoing monitoring"
+description: <DESCRIPTION>
+
+# Numerical weight for ordering pages (increments of 100)
+# Pattern: 100, 200, 300, etc. Lower numbers appear first in navigation
+weight: <WEIGHT_NUMBER>
+
+# Step number in the learning journey sequence (matches weight pattern)
+# Examples: 2, 3, 4, 5, 6, 7, 8, 9, 10
+step: <STEP_NUMBER>
+
+# Layout template – always "single-journey" for learning journey pages
+layout: single-journey
+
+# Call-to-action configuration for navigation between journey steps
+cta:
+  # Type determines the button text and styling
+  # "continue" = shows "Continue" button for intermediate steps
+  # "conclusion" = shows completion styling for final step
+  type: <CTA_TYPE>
+
+# Optional fields – include only when needed
+
+# Keywords for SEO and search – use 3-5 relevant technical terms
+# Include product names, technologies, and key concepts covered
+# Examples: ["Grafana Labs", "observability", "monitoring", "Kubernetes"]
+keywords:
+  - <KEYWORD_1>
+  - <KEYWORD_2>
+  - <KEYWORD_3>
+
+# Related journeys section – appears only on conclusion pages
+# Suggests follow-up learning paths after completing current journey
+related_journeys:
+  # Standard title used across all journey conclusion pages
+  title: Related journeys
+  # Heading text encouraging users to continue learning
+  heading: Consider taking the following journeys after you complete this journey.
+  items:
+    # Link to other complete learning journeys that build on current knowledge
+    # Examples: "Explore data using Metrics Drilldown", "Visualize metrics in a Grafana Cloud dashboard"
+    - title: <JOURNEY_TITLE>
+      # Relative path to other learning journey starting pages
+      # Pattern: '/docs/learning-journeys/journey-name/'
+      link: <JOURNEY_LINK>
+
+# Side journeys for additional exploration – appears on most pages
+# Provides optional deep-dive content related to current step
+side_journeys:
+  # Standard title with "(optional)" suffix
+  title: More to explore (optional)
+  # Contextual heading that relates to current step in journey
+  # Examples: "At this point in your journey, you can explore the following paths:"
+  heading: <SIDE_HEADING>
+  items:
+    # Links to specific documentation pages, videos, or external resources
+    # Should be directly relevant to concepts introduced in current step
+    - title: <SIDE_JOURNEY_TITLE>
+      # Can be relative docs links or external URLs
+      # Examples: '/docs/grafana/latest/explore/', 'https://www.youtube.com/watch?v=...'
+      link: <SIDE_JOURNEY_LINK>
+
+# Image configuration – only used on conclusion pages with cta type "conclusion"
+# This overrides the basic cta configuration above
+cta:
+  type: conclusion
+  image:
+    # Path to celebration/completion image
+    # Standard images: "/media/docs/learning-journey/journey-conclusion-header-1.svg"
+    src: <IMAGE_PATH>
+    # Image dimensions in pixels – use standard values for consistency
+    # Common: width: 735, height: 175
+    width: <IMAGE_WIDTH>
+    height: <IMAGE_HEIGHT>
+---

--- a/.github/instructions/learning-journey/step/markdown.md
+++ b/.github/instructions/learning-journey/step/markdown.md
@@ -1,0 +1,340 @@
+# Learning journey step content template
+
+This template gives patterns and examples for creating learning journey step content based on analysis of existing Grafana learning journey files.
+
+## Required sections and order
+
+Each learning journey step must include these sections in order:
+
+1. **YAML front matter** (step number, weight, CTA configuration)
+1. **H1 heading** (must match the `title` in front matter exactly)
+1. **Introduction paragraph** (goal of this step)
+1. **Numbered instructions** (step-by-step actions)
+1. **Optional: Verification section** (how to confirm success)
+1. **Optional: Call to action** (if using CTA front matter)
+
+## Main heading pattern
+
+- Include an H1 heading that matches the YAML front matter title exactly.
+- Use action-oriented titles starting with verbs.
+
+Always start with the same heading as the title in the front matter:
+
+```markdown
+# [Title from front matter]
+```
+
+Examples:
+
+- `# The value of Logs Drilldown`
+- `# Add Logs Drilldown visualization to a dashboard`
+- `# Create a dashboard and add a visualization`
+- `# Destination reached!{.text-center}`
+
+## Common content patterns
+
+### Business value and introduction pages
+
+**Opening paragraph pattern**: Brief description of the feature or product value.
+
+```markdown
+[Product Name] is a [description of what it does]. [Key benefit statement].
+
+With [Product name], you can:
+
+- [Benefit 1 – starts with action verb]
+- [Benefit 2 – starts with action verb]
+- [Benefit 3 – starts with action verb]
+- [Additional benefits as needed]
+```
+
+Examples:
+
+- "Grafana Logs Drilldown is a queryless experience for browsing logs..."
+- "Grafana Metrics Drilldown is a queryless experience for browsing **Prometheus-compatible** metrics..."
+- "Grafana Alloy combines the strengths of the leading telemetry collectors..."
+
+### Installation and setup pages
+
+**Standard opening**:
+
+```markdown
+In this [milestone/step], you [action description].
+
+[Optional context paragraph explaining why this step matters.]
+
+To [perform the action], complete the following steps:
+```
+
+**Step format**:
+
+```markdown
+1. [Action step with specific UI navigation]
+
+   [Optional additional context or screenshot reference]
+
+1. [Next action step]
+
+1. [Continue with numbered steps]
+```
+
+Common step patterns:
+
+- "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
+- "On the Grafana Cloud home page, open the navigation menu on the left side of the screen and click **[Menu item]**."
+- "Click **[Button name]**."
+- "Enter [value] in the **[Field name]** field."
+
+### Investigation and analysis pages
+
+**Opening structure**:
+
+```markdown
+[Brief explanation of what this step accomplishes and why it's valuable]
+
+[Description of insights you can gain from this action]
+
+- [Insight 1]
+- [Insight 2]
+- [Insight 3]
+
+## How to [perform the action]
+
+To [action description], complete the following steps:
+
+[Numbered steps]
+
+## Insights from [the action/data]
+
+The image below provides the following insights:
+
+- [Specific insight with data examples]
+- [Pattern or trend observation]
+- [Performance indicator or issue identification]
+
+![Image description](/path/to/image)
+```
+
+### Query writing pages
+
+**Structure pattern**:
+
+```markdown
+# Write a [Query language] query using the Query Builder
+
+Now that you've [previous context], it's time to write the query. A query is an expression that specifies the dataset used in the visualization.
+
+[Query language] generates [types of queries]. [Explanation of query types].
+
+## Elements of a [Query language] query
+
+A [Query language] query consists of the following basic elements:
+
+### [Element 1 name]
+
+[Description with code example in backticks]
+
+For example, [example explanation].
+
+### [Element 2 name] (optional)
+
+[Description]
+
+For example, [example explanation].
+
+## How to write a [Query language] query
+
+To write a [Query language] query using the Query Builder, complete the following steps:
+
+1. [Step with specific UI instructions]
+
+   {{< admonition type="did you know?" >}}
+   [Helpful tip or additional context]
+   {{< /admonition >}}
+
+1. [Continue with steps]
+```
+
+### Dashboard creation pages
+
+**Standard opening**:
+
+```markdown
+{{< shared-snippet path="/docs/grafana/next/dashboards/_index.md" id="dashboard-overview" >}}
+
+To [create/build] a dashboard [with specific purpose], complete the following steps:
+```
+
+Common step patterns:
+
+- "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`."
+- "Click **New > Dashboard**."
+- "Click **Add visualization**."
+- "Search for and select a data source."
+- "From the **Visualization** drop-down list in the upper right, select `[Visualization type]`."
+
+### Conclusion pages
+
+Always include a conclusion page as the last step.
+
+Name the folder `end-journey`.
+
+**Standard structure**:
+
+```markdown
+# Destination reached!{.text-center}
+
+Congratulations on completing this journey! Job well done!
+{.text-center}
+
+We hope you've enjoyed traveling with us as you:
+
+- [Achievement 1 – past tense]
+- [Achievement 2 – past tense]
+- [Achievement 3 – past tense]
+- [Additional achievements]
+```
+
+## Verification section
+
+- Use the heading "## Verify the installation" or "## Verify [action completed]" to match the step's goal
+- Provide clear instructions to confirm the step was completed successfully
+- Include specific commands or UI checks users can perform
+- Use numbered lists for verification steps, starting with 1
+- Include expected output or results users should see
+- Add explanatory text after commands describing what successful output looks like
+
+Example verification section format:
+
+```markdown
+## Verify the installation
+
+To confirm Alloy is running correctly:
+
+1. Check the service status:
+
+    <CODE_BLOCK>
+
+1. View the logs for any errors:
+
+    <CODE_BLOCK>
+
+The output should show Alloy is active and running without errors.
+```
+
+## Common phrases and patterns
+
+### Navigation instructions
+
+- "Sign in to your Grafana Cloud environment, for example `mystack.grafana.net`"
+- "On the Grafana Cloud home page, open the navigation menu on the left side of the screen"
+- "Click **[Menu item] > [Submenu item]**"
+- "In the upper right of the page"
+- "Located in the toolbar"
+
+### Transition phrases
+
+- "In the next milestone, you'll [action]"
+- "In your next milestone, you'll [action]"
+- "In your final milestone, you'll [action]"
+- "Your next step in this journey is to [action]"
+- "Having [completed previous action], [next action context]"
+
+### Instruction starters
+
+- "To [action], complete the following steps:"
+- "To [action], perform the following steps:"
+- "Complete the following steps:"
+
+### Value propositions
+
+- "This [action/feature] helps you:"
+- "By [doing action], you can:"
+- "With [feature name], you can:"
+- "[Feature] provides the following advantages:"
+
+### Conditional instructions
+
+```markdown
+| If you want to | Then |
+| -------------- | ---- |
+| [Scenario 1] | [Instructions] |
+| [Scenario 2] | [Instructions] |
+```
+
+### Admonition patterns
+
+```markdown
+{{< admonition type="did you know?" >}}
+[Helpful tip or additional context]
+{{< /admonition >}}
+
+{{< admonition type="tip" >}}
+[Performance or best practice tip]
+{{< /admonition >}}
+
+{{< admonition type="caution" >}}
+[Warning about potential issues]
+{{< /admonition >}}
+
+{{< admonition type="note" >}}
+[Important information to remember]
+{{< /admonition >}}
+```
+
+## Video integration pattern
+
+```markdown
+{{< docs/video id="[VIDEO_ID]" align="right" start="[START_TIME]" end="[END_TIME]" >}}
+
+[Context about what the video shows]
+
+{{< /docs/video >}}
+```
+
+## Shared snippets pattern
+
+```markdown
+{{< shared-snippet path="/docs/[path]/index.md" id="[snippet-id]" >}}
+```
+
+## Code examples pattern
+
+```markdown
+[Introduction sentence ending with a colon]:
+
+<CODE_BLOCK>
+
+[Explanation of the code and its purpose]
+```
+
+## Image integration pattern
+
+```markdown
+![Image description that conveys the essential information](/path/to/image)
+```
+
+## Common link patterns
+
+- Internal docs: `/docs/[product]/[version]/[path]/`
+- External links: Full URLs for external resources
+- Video links: YouTube URLs for demonstrations
+
+## Data examples pattern
+
+When showing data structures, use realistic examples:
+
+- JSON: Traffic density data, API responses
+- CSV: Timestamped data with meaningful field names
+- Metrics: CPU usage, memory consumption, error rates
+- Logs: Application logs with realistic service names
+
+## Prerequisites pattern (when applicable)
+
+```markdown
+Before you begin ensure you have the following:
+
+- [Prerequisite 1]
+- [Prerequisite 2]
+- [Additional prerequisites as needed]
+```

--- a/.github/instructions/writers-toolkit.instructions.md
+++ b/.github/instructions/writers-toolkit.instructions.md
@@ -607,3 +607,11 @@ for example don't delete shortcodes:
 ```markdown
 {{< docs/shared source="opentelemetry" lookup="grafana-cloud.md" version="" >}}
 ```
+
+## Learning journeys
+
+- [Learning journeys](learning-journey/learning-journey.instructions.md)
+- [_index.md frontmatter template](learning-journey/_index/frontmatter.yaml)
+- [_index.md Markdown content template](learning-journey/_index/markdown.md)
+- [step/index.md Frontmatter template](learning-journey/step/frontmatter.yaml)
+- [step/index.md Markdown content template](learning-journey/step/markdown.md)


### PR DESCRIPTION
Adds instructions for learning journeys.

The instructions work best for getting you started with a content structure you can iterate on. 

I've experimented creating a handful of journeys using existing docs and blog posts as context. 

It works best when specifying the specific steps and content you'd like, for example, "Create a learning journey for App O11y, use the attached resources as context. Use the following steps: 1. set up the Grafana Java SDK, 2 set up Alloy, 3 send to Cloud, 4 end journey. Use <this> article for the Alloy setup."

I've found Claude Sonnet gives better results over Gemini and OpenAI.