### PR TITLE
Add documentation CI step that checks for renamed files containing the shared shortcode

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
       security-events: write
     uses: ./.github/workflows/docs-ci.yml
     with:

--- a/build-website/action.yml
+++ b/build-website/action.yml
@@ -64,6 +64,14 @@ runs:
             });
           });
 
+    - name: Check for renamed files using the shared shortcode
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const script = require('./build-website/shared-shortcode.js');
+          await script({ context, core, github });
+
     - name: Build website
       env:
         IMAGE: ${{ inputs.image }}

--- a/build-website/shared-shortcode.js
+++ b/build-website/shared-shortcode.js
@@ -1,0 +1,58 @@
+// Check for renamed files that contain the shared shortcode and post a comment if found
+module.exports = async ({ context, core, github }) => {
+  const { data: files } = await github.rest.pulls.listFiles({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.issue.number,
+  });
+
+  const renamedFilesWithShared = [];
+
+  for (const file of files) {
+    if (file.status === "renamed" && file.additions > 0) {
+      try {
+        const { data: fileContent } = await github.rest.repos.getContent({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          path: file.filename,
+          ref: context.payload.pull_request.head.sha,
+        });
+
+        const content = Buffer.from(fileContent.content, "base64").toString(
+          "utf8",
+        );
+
+        if (content.includes("{{< shared")) {
+          renamedFilesWithShared.push({
+            oldName: file.previous_filename,
+            newName: file.filename,
+          });
+        }
+      } catch (error) {
+        core.debug(`Error checking file ${file.filename}: ${error.message}`);
+      }
+    }
+  }
+
+  if (renamedFilesWithShared.length > 0) {
+    const fileList = renamedFilesWithShared
+      .map((file) => `- \`${file.oldName}\` → \`${file.newName}\``)
+      .join("\n");
+
+    const commentBody = `⚠️ **Learning Journeys update required**
+
+This PR contains renamed files that use the \`{{< shared ... >}}\` shortcode:
+
+${fileList}
+
+These changes may affect learning journeys content. Review and update any affected learning journeys accordingly.
+If you're not sure how to update the learning journeys, ping the @grafana/docs-tooling for assistance.`;
+
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body: commentBody,
+    });
+  }
+};


### PR DESCRIPTION
Will drop some commits before merging that were used to test the behavior.

Relates to https://raintank-corp.slack.com/archives/C07R2REUULS/p1752245272948599?thread_ts=1752244152.551779&cid=C07R2REUULS

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
