### PR TITLE
Add support for "<LATEST>" placeholder

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -139,7 +139,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: jdb/deploy-preview
+          ref: main
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |


### PR DESCRIPTION
Seems like a convenient mechanism to mount the latest semantic version without having to run the full website mounts.

Tested in https://github.com/grafana/k6-docs/pull/2038.