### PR TITLE
add 'PDC' to vale dictionary

### DIFF
--- a/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
+++ b/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-370
+371
 ACL/S po:noun
 ADOT/ po:noun
 AI Observability/ po:noun
@@ -221,6 +221,7 @@ overutilization/S po:noun
 PagerDuty/ po:noun
 Parca/ po:noun
 path/S po:noun
+PDC/ po:noun
 PDF/S po:noun
 performant/ po:adjective
 Phlare/M po:noun

--- a/vale/dictionary/p.jsonnet
+++ b/vale/dictionary/p.jsonnet
@@ -3,6 +3,7 @@ local word = import './word.jsonnet';
   word.new('PagerDuty', '', 'noun') { description: 'https://www.pagerduty.com/', product: true, swaps: { 'pager[dD]uty': 'PagerDuty', Pagerduty: 'PagerDuty' } },
   word.new('Parca', '', 'noun') { product: true },
   word.new('path', 'S', 'noun') { description: 'A string that represents a file or directory location in a filesystem.', swaps: { '(?:file ?path|path ?name)': 'path', '(?:file ?path|path ?name)s': 'paths' } },
+  word.new('PDC', '', 'noun') { description: 'Private Data source Connect', product: true },
   word.new('PDF', 'S', 'noun') { abbreviation: true, elaboration: 'Portable Document Format', established_abbreviation: true },
   word.new('performant', '', 'adjective'),
   word.new('Phlare', 'M', 'noun') { product: true, swaps: { phlare: 'Phlare' } },


### PR DESCRIPTION
vale is complaining in [this PR](https://github.com/grafana/website/pull/27285/files), particularly about using "PDC" in headings. Add the term to the vale dictionary

<!--
Thank you for contributing to Writers' Toolkit!

Consider the following checklist to make sure your PR is most effective.
-->

- [x] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
