### PR TITLE
Update style guide to avoid directional language

### DIFF
--- a/docs/sources/write/style-guide/inclusive-writing/index.md
+++ b/docs/sources/write/style-guide/inclusive-writing/index.md
@@ -135,3 +135,22 @@ Hyphenate when you're modifying a noun. For example:
 - scroll toward the lower right
 
 Don't use the word _hand_ as a qualifier like in _right-hand corner_.
+
+### Avoid directional language
+
+Language that relies only on spatial direction doesn't help users with visual disabilities or those who use screen readers. Remove directional language from your documentation when possible, and add language that doesn't depend on spatial cues to help users navigate.
+
+Use:
+
+- In the previous section
+- In the following table
+- The next step
+- Earlier in this topic
+
+Don't use:
+
+- In the section above
+- The table below
+- To the right
+- See the sidebar on the left
+


### PR DESCRIPTION
This pull request includes documentation improvements focused on clarity and accessibility, specifically:

Updated the section in the style guide to advise against using spatial directional language (like "above", "below", "to the right") and provided alternative phrases that are more accessible to users with visual disabilities or those using screen readers.

Closes https://github.com/grafana/website/issues/27507

- [X] I've used a relevant pull request (PR) title.
- [x] I've added a link to any relevant issues in the PR description.
- [x] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
