### PR TITLE
Rely on workflow to gate skip or success

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,28 +1,18 @@
 policy:
   approval:
-    - or:
-      - documentation validation passes
-      - no documentation changes
+    - documentation validation passes or no documentation changes
 
 approval_rules:
-  - name: documentation validation passes
+  - name: documentation validation passes or no documentation changes
     if:
-      changed_files:
+      file_not_deleted:
         paths:
-          - ^docs/sources/.+$
-          - ^vale/.+$
+          - .github/workflows/validate-documentation.yml
     requires:
       conditions:
         has_workflow_result:
           conclusions:
             - success
-          workflows:
-            - .github/workflows/validate-documentation.yml
-  - name: no documentation changes
-    requires:
-      conditions:
-        has_workflow_result:
-          conclusions:
             - skipped
           workflows:
             - .github/workflows/validate-documentation.yml


### PR DESCRIPTION
Codifying the predicate in two approval rules duplicates the definition of changed files that need to be checked.
This implementation relies on the workflow to correctly codify what changed files trigger it.

We protect ourselves from removal of the workflow to trigger skipping the CI.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
