### PR TITLE
chore: update commit hash for build-website/v1 tag

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build website
-        uses: grafana/writers-toolkit/build-website@44d8e2b29fbbdba5c3614ddcfc29be47e5f9e61c # build-website/v1
+        uses: grafana/writers-toolkit/build-website@7e0981fdbf5a4446e309ecb655596a71113d60ae # build-website/v1
         with:
           image: ${{ inputs.build-website-image }}
           source_directory: ${{ inputs.build-website-source-directory }}

--- a/publish-technical-documentation-release/action.yaml
+++ b/publish-technical-documentation-release/action.yaml
@@ -85,7 +85,7 @@ runs:
       shell: bash
 
     - name: Build website
-      uses: grafana/writers-toolkit/build-website@44d8e2b29fbbdba5c3614ddcfc29be47e5f9e61c # build-website/v1
+      uses: grafana/writers-toolkit/build-website@7e0981fdbf5a4446e309ecb655596a71113d60ae # build-website/v1
       with:
         source_directory: ${{ inputs.source_directory }}
         website_directory: ${{ inputs.website_directory }}

--- a/publish-technical-documentation/action.yml
+++ b/publish-technical-documentation/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Build website
-      uses: grafana/writers-toolkit/build-website@44d8e2b29fbbdba5c3614ddcfc29be47e5f9e61c # build-website/v1
+      uses: grafana/writers-toolkit/build-website@7e0981fdbf5a4446e309ecb655596a71113d60ae # build-website/v1
       with:
         source_directory: ${{ inputs.source_directory }}
         website_directory: ${{ inputs.website_directory }}


### PR DESCRIPTION
GH actions cross dependencies are a pain...

Pulling in the latest version of build-website/v1 to use the fix in #1231 