### PR TITLE
Fix documentation build race condition

### DIFF
--- a/docs/make-docs
+++ b/docs/make-docs
@@ -8,6 +8,14 @@
 # [Semantic versioning](https://semver.org/) is used to help the reader identify the significance of changes.
 # Changes are relevant to this script and the support docs.mk GNU Make interface.
 #
+# ## 10.1.0 (2025-11-11)
+#
+# ### Fixed
+#
+# - Extend readiness probes to prevent confusing output.
+#
+#   Before, the probes could fail too soon and long an error message which contradicted the service starting up.
+#
 # ## 10.0.0 (2025-10-13)
 #
 # ### Changed
@@ -732,6 +740,10 @@ await_build() {
   url="$1"
   req="$(if command -v curl >/dev/null 2>&1; then echo 'curl -s -o /dev/null'; else echo 'wget -q'; fi)"
 
+  # Initial delay to allow container to start before beginning healthchecks
+  sleep 3
+
+  # Fast retries for initial startup (10 attempts, 1 second apart)
   i=1
   max=10
   while [ "${i}" -ne "${max}" ]
@@ -760,6 +772,37 @@ POSIX_HERESTRING
     fi
   done
 
+  # Continue checking with longer intervals for slower builds
+  # This prevents false positives for large builds that take longer to start
+  i=1
+  max=20
+  while [ "${i}" -ne "${max}" ]
+  do
+    sleep 2
+    debg "Continuing to check web server (build may be taking longer than expected)."
+    i=$((i + 1))
+
+    if ${req} "${url}"; then
+      printf '\r\nView documentation locally:\r\n'
+      for x in ${url_src_dst_vers}; do
+        IFS='^' read -r url _ _ <<POSIX_HERESTRING
+$x
+POSIX_HERESTRING
+
+        if [ -n "${url}" ]; then
+          if [ "${url}" != arbitrary ]; then
+            printf '\r  %s\r\n' "${url}"
+          fi
+        fi
+      done
+      printf '\r\nPress Ctrl+C to stop the server\r\n'
+
+      unset i max req url
+      return
+    fi
+  done
+
+  # Only log error after extended checking period (total ~60 seconds)
   printf '\r\n'
   errr 'The build was interrupted or a build error occurred, check the previous logs for possible causes.'
   note 'You might need to use Ctrl+C to end the process.'


### PR DESCRIPTION
Fix: Make `docs/make-docs` build healthcheck more resilient

<!--
Thank you for contributing to Writers' Toolkit!

Consider the following checklist to make sure your PR is most effective.
-->

- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).

The `docs/make-docs` build script often logged a premature error ("ERRR: The build was interrupted...") due to a race condition in the `await_build` healthcheck. The previous implementation started checks too early and had a short timeout, leading to false positives for slower builds.

This PR improves the resilience of `await_build` by:
- Adding an initial 3-second delay before starting healthchecks.
- Implementing a two-phase retry mechanism: 10 fast retries (1s apart) followed by 20 slower retries (2s apart).
- Extending the total healthcheck timeout to approximately 60 seconds before an error is logged.

This change prevents premature error messages and ensures the build script waits adequately for the documentation server to become available.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C07R2REUULS/p1762448877389419?thread_ts=1762448877.389419&cid=C07R2REUULS)

<a href="https://cursor.com/background-agent?bcId=bc-0c2b134c-b367-4604-86b1-cac877ab94ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c2b134c-b367-4604-86b1-cac877ab94ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

