### PR TITLE
Update dictionary and regenerate Vale files

### DIFF
--- a/docs/sources/review/lint-prose/rules.md
+++ b/docs/sources/review/lint-prose/rules.md
@@ -2,7 +2,7 @@
 date: "2024-06-25"
 description: A description of every Grafana Labs prose linting rule.
 menuTitle: Rules
-review_date: "2025-05-17"
+review_date: "2025-11-13"
 title: Vale rules
 ---
 
@@ -369,7 +369,7 @@ Did you really mean _`<CURRENT TEXT>`_?
 The Grafana dictionary might not know of this word yet.
 
 To add a new word, refer to [Add words to the Grafana Labs dictionary](https://grafana.com/docs/writers-toolkit/review/lint-prose/dictionary/add-words/).
-Alternatively, raise an [issue](https://github.com/grafana/writers-toolkit/issues/new?title=Grafana.Spelling%20%3CWORD%3E) and a maintainer will add it for you.
+Alternatively, raise an [issue](https://github.com/grafana/writers-toolkit/issues/new?title=Grafana.Spelling%%3A%%20%[1]s) and a maintainer will add it for you.
 
 For UI elements, use [bold formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
 The spell checker doesn't check words with bold formatting.
@@ -819,6 +819,7 @@ _`<CURRENT TEXT>`_ was matched by one or more of the following regular expressio
 - `JMESPath's`
 - `journald's`
 - `Jsonnet's`
+- `Keycloak's`
 - `Kibana's`
 - `Killercoda's`
 - `Kinesis'`
@@ -850,6 +851,7 @@ _`<CURRENT TEXT>`_ was matched by one or more of the following regular expressio
 - `OTel's`
 - `PagerDuty's`
 - `Parca's`
+- `PDC's`
 - `Phlare's`
 - `Pinecone's`
 - `Podman's`
@@ -873,6 +875,7 @@ _`<CURRENT TEXT>`_ was matched by one or more of the following regular expressio
 - `Splunk's`
 - `SSM's`
 - `SUSE's`
+- `Team Sync's`
 - `Tempo's`
 - `Thanos'`
 - `Threema's`
@@ -883,6 +886,7 @@ _`<CURRENT TEXT>`_ was matched by one or more of the following regular expressio
 - `Webex's`
 - `WildFly's`
 - `windows_exporter's`
+- `YugabyteDB's`
 - `Zipkin's`
 
 [More information ->](https://developers.google.com/style/possessives#product,-feature,-and-company-names)
@@ -1151,6 +1155,7 @@ Use _`<REPLACEMENT TEXT>`_ instead of _`<CURRENT TEXT>`_.
 | `whitelisted`                                                     | `allowlisted`              |
 | `whitelisting`                                                    | `allowlisting`             |
 | `whitelists`                                                      | `allowlists`               |
+| `yugabyte`                                                        | `YugabyteDB`               |
 
 [More information ->](https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/)
 

--- a/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
+++ b/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-378
+379
 ACL/S po:noun
 ADOT/ po:noun
 AI Observability/ po:noun
@@ -203,6 +203,7 @@ mixin/S po:noun
 Moodle/ po:noun
 MySQL/ po:noun
 namespace/S po:noun
+navigation/S po:noun
 NAT/ po:noun
 nginx/ po:noun
 Netlink/ po:noun

--- a/vale/dictionary/n.jsonnet
+++ b/vale/dictionary/n.jsonnet
@@ -1,6 +1,7 @@
 local word = import './word.jsonnet';
 [
   word.new('namespace', 'S', 'noun'),
+  word.new('navigation', 'S', 'noun'),
   word.new('NAT', '', 'noun') { abbreviation: true, description: 'Network Address Translation', established_abbreviation: true },
   word.new('nginx', '', 'noun'),
   word.new('Netlink', '', 'noun') { product: true, description: 'Netlink is a socket family used for inter-process communication (IPC) between both the kernel and userspace processes: https://en.wikipedia.org/wiki/Netlink' },


### PR DESCRIPTION
- [x] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).

This PR adds "navigation" to the Grafana dictionary with a pluralization affix. This ensures Vale correctly recognizes both "navigation" and "navigations" as valid terms.

The Vale dictionary files have been regenerated locally to reflect this change.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C5PG2JK8W/p1763013475286899?thread_ts=1763013475.286899&cid=C5PG2JK8W)

<a href="https://cursor.com/background-agent?bcId=bc-b6a86225-1d34-458b-937c-6c44e7b8fad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6a86225-1d34-458b-937c-6c44e7b8fad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

