### PR TITLE
Add "tolerations" word from k8s specs (#1365)

### DIFF
--- a/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
+++ b/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-398
+400
 ACL/S po:noun
 actionability/ po:noun
 ADOT/ po:noun
@@ -344,6 +344,7 @@ Thanos/ po:noun
 Threema/ po:noun
 Timestream/ po:noun
 TLS/ po:noun
+toleration/S po:noun
 toolset/S po:noun
 tooltip/S po:noun
 tracepoint/S po:noun

--- a/vale/dictionary/t.jsonnet
+++ b/vale/dictionary/t.jsonnet
@@ -10,7 +10,7 @@ local word = import './word.jsonnet';
   word.new('Threema', '', 'noun') { description: 'https://threema.ch/en', product: true, swaps: { threema: 'Threema' } },
   word.new('Timestream', '', 'noun') { Amazon: true, product: true },
   word.new('TLS', '', 'noun') { abbreviation: true, description: 'A cryptographic protocol designed to provide secure communications over network.', elaboration: 'Transport Layer Security', established_abbreviation: true },
-  word.new('Tolerations', '', 'noun'),
+  word.new('toleration', 'S', 'noun') { description: 'A Kubernetes Pod specification field that allows Pods to be scheduled on nodes with matching taints.' },
   word.new('toolset', 'S', 'noun'),
   word.new('tooltip', 'S', 'noun'),
   word.new('tracepoint', 'S', 'noun'),

--- a/vale/dictionary/t.jsonnet
+++ b/vale/dictionary/t.jsonnet
@@ -10,6 +10,7 @@ local word = import './word.jsonnet';
   word.new('Threema', '', 'noun') { description: 'https://threema.ch/en', product: true, swaps: { threema: 'Threema' } },
   word.new('Timestream', '', 'noun') { Amazon: true, product: true },
   word.new('TLS', '', 'noun') { abbreviation: true, description: 'A cryptographic protocol designed to provide secure communications over network.', elaboration: 'Transport Layer Security', established_abbreviation: true },
+  word.new('Tolerations', '', 'noun'),
   word.new('toolset', 'S', 'noun'),
   word.new('tooltip', 'S', 'noun'),
   word.new('tracepoint', 'S', 'noun'),


### PR DESCRIPTION
"Tolerations" is a spec field from Kubernetes. I got error from Vale on it in this PR:

https://github.com/grafana/website/pull/30199/changes

- [X] I've used a relevant pull request (PR) title.
- [X] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
