### PR TITLE
Add interactive guide deploy preview script

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -84,6 +84,9 @@ on:
       title:
         required: true
         type: string
+      build_script:
+        description: "Build script to run. Allowed values: build, build-interactive-tutorials. Defaults to build."
+        type: string
 
 env:
   CLOUD_RUN_REGION: us-south1
@@ -98,6 +101,7 @@ env:
   RELATIVE_PREFIX: ${{ inputs.relative_prefix }}
   IMAGE: ${{ inputs.image }}
   SOURCES: ${{ inputs.sources }}
+  BUILD_SCRIPT: ${{ inputs.build_script }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.repo }}-${{ inputs.title }}-${{ github.event.pull_request.number || github.ref }}
@@ -144,7 +148,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: main
+          ref: jdb/deploy-preview
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |
@@ -187,7 +191,13 @@ jobs:
           IMAGE: ${{ env.IMAGE }}
           SOURCES: ${{ env.SOURCES }}
           BRANCH: ${{ env.BRANCH }}
-        run: ./deploy-preview-files/deploy-preview/build
+        run: |
+          script="${BUILD_SCRIPT:-build}"
+          case "${script}" in
+            build | build-interactive-tutorials) ;;
+            *) echo "build_script must be one of: build, build-interactive-tutorials"; exit 1 ;;
+          esac
+          "./deploy-preview-files/deploy-preview/${script}"
 
       - name: Print build header value
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -287,7 +297,7 @@ jobs:
 
       - name: Send commit status
         uses: ouzi-dev/commit-status-updater@26588d166ff273fc4c0664517359948f7cdc9bf1 # v2.0.2
-        if: "!env.WEBSITE_DIRECTORY && (github.event.action == 'opened' || github.event.action == 'synchronize')"
+        if: "!env.WEBSITE_DIRECTORY && env.SOURCES && (github.event.action == 'opened' || github.event.action == 'synchronize')"
         with:
           name: deploy_preview
           status: "${{ job.status }}"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -148,7 +148,7 @@ jobs:
         if: github.event.action == 'opened' || github.event.action == 'synchronize'
         with:
           repository: "grafana/writers-toolkit"
-          ref: jdb/deploy-preview
+          ref: main
           path: deploy-preview-files
           persist-credentials: false
           sparse-checkout: |

--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [[ -n "${RUNNER_DEBUG+x}" ]]; then
+	set -x
+fi
+
+gh repo clone grafana/interactive-tutorials src/interactive-tutorials
+(cd src/interactive-tutorials && gh pr checkout "${BRANCH}")
+
+DATA_DIR=$(mktemp -d)
+CONTENT_DIR=$(mktemp -d)
+trap 'rm -rf "${DATA_DIR}" "${CONTENT_DIR}"' EXIT
+
+while IFS= read -r rel_path; do
+	rel_dir=$(dirname "${rel_path}")
+	mkdir -p "${DATA_DIR}/${rel_dir}"
+	cp "src/interactive-tutorials/${rel_path}" "${DATA_DIR}/${rel_path}"
+done < <(git -C src/interactive-tutorials ls-files '**/content.json')
+
+write_page() {
+  local out="${1}"
+  local website_yaml="${2}"
+  local content_json="${3}"
+  local manifest_json="${4}"
+  local pathfinder_data="${5}"
+  local title description
+
+  title=$(jq '.title // .id // ""' "${content_json}" 2>/dev/null) || title='""'
+  description=$(jq '.description // ""' "${manifest_json}" 2>/dev/null) || description='""'
+
+  mkdir -p "$(dirname "${out}")"
+  {
+    echo "---"
+    [[ -f "${website_yaml}" ]] && cat "${website_yaml}"
+    echo "type: docs"
+    echo "title: ${title}"
+    echo "description: ${description}"
+    echo "pathfinder_data: ${pathfinder_data}"
+    echo "---"
+    echo ""
+    echo "{{< pathfinder/json >}}"
+  } > "${out}"
+  echo "wrote ${out}"
+}
+
+mkdir -p "${CONTENT_DIR}"
+
+index_body=""
+
+for lj_dir in src/interactive-tutorials/*-lj; do
+	[[ -d "${lj_dir}" ]] || continue
+	lj_name=$(basename "${lj_dir}")
+	slug="${lj_name%-lj}"
+
+	write_page \
+		"${CONTENT_DIR}/${slug}/_index.md" \
+		"${lj_dir}/website.yaml" \
+		"${lj_dir}/content.json" \
+		"${lj_dir}/manifest.json" \
+		"${lj_name}"
+
+	path_title=$(jq -r '.title // .id // ""' "${lj_dir}/content.json" 2>/dev/null || echo "${slug}")
+	index_body+="- [${path_title}](/docs/learning-paths/${slug}/)"$'\n'
+
+	for milestone_dir in "${lj_dir}"/*/; do
+		[[ -d "${milestone_dir}" ]] || continue
+		[[ -f "${milestone_dir}/content.json" ]] || continue
+		milestone_name=$(basename "${milestone_dir}")
+
+		write_page \
+			"${CONTENT_DIR}/${slug}/${milestone_name}/index.md" \
+			"${milestone_dir}/website.yaml" \
+			"${milestone_dir}/content.json" \
+			"${milestone_dir}/manifest.json" \
+			"${lj_name}/${milestone_name}"
+	done
+done
+
+cat > "${CONTENT_DIR}/_index.md" <<EOMD
+---
+title: Learning paths preview
+menuTitle: Learning paths
+weight: 100
+---
+
+${index_body}
+EOMD
+
+echo "content.json files found in checkout:"
+git -C src/interactive-tutorials ls-files '**/content.json' | head -5 || echo "git ls-files failed"
+echo "DATA_DIR: ${DATA_DIR}"
+echo "DATA_DIR file count: $(find "${DATA_DIR}" -type f | wc -l)"
+find "${DATA_DIR}" -type f | head -5 || true
+echo "CONTENT_DIR: ${CONTENT_DIR}"
+echo "CONTENT_DIR file count: $(find "${CONTENT_DIR}" -type f | wc -l)"
+find "${CONTENT_DIR}" -type f | head -5 || true
+
+docker run \
+	--volume "${PWD}/dist:/hugo/dist" \
+	--volume "${DATA_DIR}:/hugo/data/docs/interactive-learning" \
+	--volume "${CONTENT_DIR}:/hugo/content/docs/learning-paths" \
+	--rm "${IMAGE:-grafana/docs-base:latest}" \
+	  /bin/bash -c 'echo "Data dir:"; ls /hugo/data/docs/interactive-learning/ | head -5; echo "Content dir:"; ls /hugo/content/docs/learning-paths/ | head -5; HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify 2>&1 | tail -5'

--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -113,4 +113,4 @@ docker run \
 	--volume "${DATA_DIR}:/hugo/data/docs/interactive-learning" \
 	--volume "${CONTENT_DIR}:/hugo/content/docs/learning-paths" \
 	--rm "${IMAGE:-grafana/docs-base:latest}" \
-	  /bin/bash -c 'echo "Data dir:"; ls /hugo/data/docs/interactive-learning/ | head -5; echo "Content dir:"; ls /hugo/content/docs/learning-paths/ | head -5; HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify 2>&1 | tail -5'
+	  /bin/bash -c 'set -o pipefail; echo "Data dir:"; ls /hugo/data/docs/interactive-learning/ | head -5; echo "Content dir:"; ls /hugo/content/docs/learning-paths/ | head -5; HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify 2>&1 | tail -5'

--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -6,6 +6,17 @@ if [[ -n "${RUNNER_DEBUG+x}" ]]; then
 	set -x
 fi
 
+require_env() {
+	local name="${1}"
+	if [[ -z "${!name:-}" ]]; then
+		echo "Error: required environment variable '${name}' is not set or is empty." >&2
+		exit 1
+	fi
+}
+
+require_env BRANCH
+require_env GH_TOKEN
+
 gh repo clone grafana/interactive-tutorials src/interactive-tutorials
 (cd src/interactive-tutorials && gh pr checkout "${BRANCH}")
 

--- a/deploy-preview/nginx.conf
+++ b/deploy-preview/nginx.conf
@@ -70,6 +70,12 @@ http {
       alias /usr/share/nginx/dist/;
     }
 
+    location /web {
+      proxy_pass https://grafana.com/web;
+      proxy_ssl_server_name on;
+      resolver 8.8.8.8 8.8.4.4 ipv6=off;
+    }
+
     location /static {
       proxy_pass https://grafana.com/static;
     }


### PR DESCRIPTION
Needs to have the references to this branch replaced with `main` before merge.

Simply adds an alternative build script that can be selected using the input parameter.
Tested out in https://github.com/grafana/interactive-tutorials/pull/299.