### PR TITLE
Replace Vale codeql reporting with GitHub PR comments

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
           sparse-checkout: ${{ inputs.sparse-checkout }}
-      - uses: grafana/writers-toolkit/vale-action@f49dd90f007967990095ac2d18c5bdf37b412a5f # vale-action/v1.4.5
+      - uses: ./vale-action
         with:
           directory: ${{ inputs.vale-directory }}
           filter: ${{ inputs.vale-filter }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -14,7 +14,7 @@ description: |
   To use the Vale step, you'll need the following additional permissions:
 
   ```yaml
-  security-events: write
+  pull-requests: write
   ```
 on:
   workflow_call:
@@ -118,8 +118,7 @@ jobs:
     if: inputs.vale
     permissions:
       contents: read
-      pull-requests: read
-      security-events: write
+      pull-requests: write
     runs-on: ubuntu-latest
     container:
       image: grafana/vale:latest # zizmor: ignore[unpinned-images] We control this image and use :latest tag, so we don't need to pin the SHA.

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -27,7 +27,6 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
-      security-events: write
     uses: ./.github/workflows/docs-ci.yml
     with:
       build: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build.conf
 /dist
 /vale/Grafana.zip
 vale/tools/inhibit-rules
+/vale-action/node_modules/

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -31,7 +31,7 @@ Use it as the source of truth for voice and tone, grammar, style, templates, and
 Writers' Toolkit helps you to create technical documentation that's consistent and applies the voice and tone in use at Grafana Labs.
 
 The style guide extends [Google's developer documentation style guide](https://developers.google.com/style).
-If you can't find guidance on a specific topic in Writers' Toolkit, refer to Google's style guide.
+If you can't find guidance on a specific topic in Writers' Toolkit, e.g. punctuation, refer to Google's style guide.
 
 If it's your first time using the guide, start with the [Get started](https://grafana.com/docs/writers-toolkit/get-started/) section.
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -26,6 +26,7 @@ title: Writers' Toolkit
 # Writers' Toolkit
 
 Writers' Toolkit is for anyone who writes or edits customer-facing technical documentation for Grafana Labs.
+It includes a toolchain for linting and validating documentation.
 Use it as the source of truth for voice and tone, grammar, style, templates, and more.
 
 Writers' Toolkit helps you to create technical documentation that's consistent and applies the voice and tone in use at Grafana Labs.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -26,13 +26,12 @@ title: Writers' Toolkit
 # Writers' Toolkit
 
 Writers' Toolkit is for anyone who writes or edits customer-facing technical documentation for Grafana Labs.
-It includes a toolchain for linting and validating documentation.
 Use it as the source of truth for voice and tone, grammar, style, templates, and more.
 
 Writers' Toolkit helps you to create technical documentation that's consistent and applies the voice and tone in use at Grafana Labs.
 
 The style guide extends [Google's developer documentation style guide](https://developers.google.com/style).
-If you can't find guidance on a specific topic in Writers' Toolkit, e.g. punctuation, refer to Google's style guide.
+If you can't find guidance on a specific topic in Writers' Toolkit, refer to Google's style guide.
 
 If it's your first time using the guide, start with the [Get started](https://grafana.com/docs/writers-toolkit/get-started/) section.
 

--- a/vale-action/action.yml
+++ b/vale-action/action.yml
@@ -32,70 +32,27 @@ runs:
       if: github.event_name == 'pull_request' && ! contains(github.event.pull_request.body, '<!-- vale = NO -->')
       env:
         FILES: ${{ steps.changed-files.outputs.all_changed_files || inputs.directory }}
-        FILTER: --filter=${{ inputs.filter }}
+        FILTER: ${{ inputs.filter }}
         GITHUB_TOKEN: ${{ github.token }}
-        OWNER: ${{ github.repository_owner }}
-        REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         if [ -n "${RUNNER_DEBUG+x}" ]; then
           set -x
         fi
 
+        filter_arg=""
+        if [ -n "${FILTER}" ]; then
+          filter_arg="--filter=${FILTER}"
+        fi
+
         (cd /etc/vale && vale sync)
-        vale "${FILTER}" --no-exit --output=/etc/vale/sarif.tmpl ${FILES} > unfiltered.sarif
-        /bin/filter-sarif "${OWNER}" "${REPO#${OWNER}/}" "${PR_NUMBER}" unfiltered.sarif > vale.sarif
+        vale ${filter_arg} --no-exit --output=line ${FILES}
+        vale ${filter_arg} --no-exit --output=JSON ${FILES} > vale.json
       shell: sh
 
-    - name: Create annotations from SARIF
-      if: failure() && github.event.repository.private && github.event_name == 'pull_request'
+    - name: Post inline PR review comments
+      if: github.event_name == 'pull_request' && ! contains(github.event.pull_request.body, '<!-- vale = NO -->')
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          const fs = require('fs');
-          const sarif = JSON.parse(fs.readFileSync('vale.sarif', 'utf8'));
-
-          for (const run of sarif.runs) {
-            for (const result of run.results) {
-              const location = result.locations[0];
-              const path = location.physicalLocation.artifactLocation.uri;
-              const region = location.physicalLocation.region;
-              const line = region.startLine;
-              const startColumn = region.startColumn;
-              const endColumn = region.endColumn;
-
-              const options = {
-                title: 'Vale',
-                file: path,
-                startLine: line,
-                startColumn: startColumn
-              };
-
-              if (endColumn) {
-                options.endColumn = endColumn;
-              }
-
-              switch(result.level) {
-                case 'error':
-                  core.error(result.message.text, options);
-                  break;
-                case 'warning':
-                  core.warning(result.message.text, options);
-                  break;
-                default:
-                  core.notice(result.message.text, options);
-              }
-            }
-          }
-
-    - name: Output SARIF file
-      if: failure() && github.event.repository.private && github.event_name != 'pull_request'
-      run: cat vale.sarif
-      shell: sh
-
-    - name: Upload SARIF file
-      if: failure() && !github.event.repository.private
-      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
-      with:
-        sarif_file: vale.sarif
-        category: Vale
+          const script = require(`${process.env.GITHUB_ACTION_PATH}/report-vale.js`);
+          await script({ context, core, github });

--- a/vale-action/package-lock.json
+++ b/vale-action/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "3.0.1",
         "@actions/github": "9.1.1",
         "@types/node": "24.12.0",
+        "ts-node": "10.9.2",
         "typescript": "5.9.3"
       },
       "engines": {
@@ -84,6 +85,47 @@
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
@@ -224,15 +266,77 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
@@ -240,6 +344,23 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
@@ -265,6 +386,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -281,6 +453,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -312,6 +485,23 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/vale-action/package-lock.json
+++ b/vale-action/package-lock.json
@@ -1,0 +1,317 @@
+{
+  "name": "vale-action",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vale-action",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@actions/core": "3.0.1",
+        "@actions/github": "9.1.1",
+        "@types/node": "24.12.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/vale-action/package.json
+++ b/vale-action/package.json
@@ -5,6 +5,7 @@
     "@actions/core": "3.0.1",
     "@actions/github": "9.1.1",
     "@types/node": "24.12.0",
+    "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },
   "engines": {
@@ -15,7 +16,8 @@
   "name": "vale-action",
   "private": true,
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --require ts-node/register --test suggestion.test.ts"
   },
   "version": "1.0.0"
 }

--- a/vale-action/package.json
+++ b/vale-action/package.json
@@ -1,0 +1,21 @@
+{
+  "author": "@jdbaldry",
+  "description": "Reports Vale linting results as inline pull request review comments.",
+  "devDependencies": {
+    "@actions/core": "3.0.1",
+    "@actions/github": "9.1.1",
+    "@types/node": "24.12.0",
+    "typescript": "5.9.3"
+  },
+  "engines": {
+    "node": ">=22",
+    "npm": ">=10"
+  },
+  "license": "Apache-2.0",
+  "name": "vale-action",
+  "private": true,
+  "scripts": {
+    "build": "tsc"
+  },
+  "version": "1.0.0"
+}

--- a/vale-action/report-vale.js
+++ b/vale-action/report-vale.js
@@ -34,7 +34,16 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("fs"));
-const COMMENT_MARKER = "<!-- vale-action -->";
+function commentMarker(check, match) {
+    return `<!-- vale-action check="${check}" match="${match}" -->`;
+}
+function parseMarker(body) {
+    const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
+    if (!m) {
+        return undefined;
+    }
+    return { check: m[1], match: m[2] };
+}
 const LINK_TEXT = {
     "developers.google.com": "Google developer documentation style guide",
     "grafana.com": "Grafana Writers' Toolkit",
@@ -86,10 +95,14 @@ function formatComment(alert, filePath) {
         : "";
     const suggestion = buildSuggestion(alert, filePath);
     const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
-    return `${COMMENT_MARKER}
+    const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
+    const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
+    const footer = "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
+        ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
+    return `${commentMarker(alert.Check, alert.Match)}
 **${alert.Check}** (${alert.Severity})
 
-${alert.Message.trimEnd()}${suggestionBlock}${reference}`;
+${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
 }
 module.exports = async ({ context, core, github, }) => {
     const raw = fs.readFileSync("vale.json", "utf-8");
@@ -110,13 +123,14 @@ module.exports = async ({ context, core, github, }) => {
         repo,
         pull_number: pullNumber,
     });
-    const existingKeys = new Set(existingComments
-        .filter((c) => c.body.startsWith(COMMENT_MARKER))
-        .map((c) => `${c.path}:${c.line}:${c.body}`));
+    const existingKeys = new Set(existingComments.flatMap((c) => {
+        const parsed = parseMarker(c.body);
+        return parsed ? [`${c.path}:${parsed.check}:${parsed.match}`] : [];
+    }));
     for (const [filePath, alerts] of Object.entries(valeOutput)) {
         for (const alert of alerts) {
             const body = formatComment(alert, filePath);
-            const dedupeKey = `${filePath}:${alert.Line}:${body}`;
+            const dedupeKey = `${filePath}:${alert.Check}:${alert.Match}`;
             if (existingKeys.has(dedupeKey)) {
                 continue;
             }

--- a/vale-action/report-vale.js
+++ b/vale-action/report-vale.js
@@ -1,0 +1,97 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = __importStar(require("fs"));
+const COMMENT_MARKER = "<!-- vale-action -->";
+const SEVERITY_EMOJI = {
+    error: "🔴",
+    warning: "🟡",
+    suggestion: "🔵",
+};
+function formatComment(alert) {
+    const emoji = SEVERITY_EMOJI[alert.Severity];
+    const link = alert.Link ? `\n\n[Style guide](${alert.Link})` : "";
+    return `${COMMENT_MARKER}
+${emoji} **${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${link}`;
+}
+module.exports = async ({ context, core, github }) => {
+    const raw = fs.readFileSync("vale.json", "utf-8");
+    if (!raw.trim()) {
+        return;
+    }
+    const valeOutput = JSON.parse(raw);
+    const { owner, repo } = context.repo;
+    const pullNumber = context.issue.number;
+    const payload = context.payload;
+    const commitSha = payload.pull_request?.head?.sha;
+    if (!commitSha) {
+        core.setFailed("Could not determine the head commit SHA.");
+        return;
+    }
+    const { data: existingComments } = await github.rest.pulls.listReviewComments({
+        owner,
+        repo,
+        pull_number: pullNumber,
+    });
+    const existingKeys = new Set(existingComments
+        .filter((c) => c.body.startsWith(COMMENT_MARKER))
+        .map((c) => `${c.path}:${c.line}:${c.body}`));
+    for (const [filePath, alerts] of Object.entries(valeOutput)) {
+        for (const alert of alerts) {
+            const body = formatComment(alert);
+            const dedupeKey = `${filePath}:${alert.Line}:${body}`;
+            if (existingKeys.has(dedupeKey)) {
+                continue;
+            }
+            try {
+                await github.rest.pulls.createReviewComment({
+                    owner,
+                    repo,
+                    pull_number: pullNumber,
+                    commit_id: commitSha,
+                    path: filePath,
+                    line: alert.Line,
+                    body,
+                });
+            }
+            catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                core.warning(`Could not post comment on ${filePath}:${alert.Line}: ${message}`);
+            }
+        }
+    }
+};

--- a/vale-action/report-vale.js
+++ b/vale-action/report-vale.js
@@ -34,75 +34,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("fs"));
-function commentMarker(check, match) {
-    return `<!-- vale-action check="${check}" match="${match}" -->`;
-}
-function parseMarker(body) {
-    const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
-    if (!m) {
-        return undefined;
-    }
-    return { check: m[1], match: m[2] };
-}
-const LINK_TEXT = {
-    "developers.google.com": "Google developer documentation style guide",
-    "grafana.com": "Grafana Writers' Toolkit",
-    "html.spec.whatwg.org": "HTML specification",
-    "docs.aws.amazon.com": "AWS documentation",
-};
-function linkText(url) {
-    try {
-        const { hostname } = new URL(url);
-        return LINK_TEXT[hostname] ?? hostname;
-    }
-    catch {
-        return "style guide";
-    }
-}
-function buildSuggestion(alert, filePath) {
-    const { Name, Params } = alert.Action;
-    if (Name !== "replace" && Name !== "remove") {
-        return null;
-    }
-    const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-    const line = lines[alert.Line - 1];
-    if (line === undefined) {
-        return null;
-    }
-    const [start, end] = alert.Span;
-    const before = line.slice(0, start - 1);
-    const after = line.slice(end);
-    let corrected;
-    if (Name === "remove") {
-        corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
-    }
-    else {
-        const first = Params?.[0] ?? "";
-        corrected = before + first + after;
-    }
-    let suggestion = "```suggestion\n" + corrected + "\n```";
-    if (Name === "replace" && Params && Params.length > 1) {
-        const alternatives = Params.slice(1)
-            .map((p) => `\`${p}\``)
-            .join(", ");
-        suggestion += `\n\nAlternatives: ${alternatives}`;
-    }
-    return suggestion;
-}
-function formatComment(alert, filePath) {
-    const reference = alert.Link
-        ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
-        : "";
-    const suggestion = buildSuggestion(alert, filePath);
-    const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
-    const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
-    const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
-    const footer = "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
-        ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
-    return `${commentMarker(alert.Check, alert.Match)}
-**${alert.Check}** (${alert.Severity})
-
-${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
+const suggestion_1 = require("./suggestion");
+function readLine(filePath, lineNumber) {
+    return fs.readFileSync(filePath, "utf-8").split("\n")[lineNumber - 1];
 }
 module.exports = async ({ context, core, github, }) => {
     const raw = fs.readFileSync("vale.json", "utf-8");
@@ -124,12 +58,13 @@ module.exports = async ({ context, core, github, }) => {
         pull_number: pullNumber,
     });
     const existingKeys = new Set(existingComments.flatMap((c) => {
-        const parsed = parseMarker(c.body);
+        const parsed = (0, suggestion_1.parseMarker)(c.body);
         return parsed ? [`${c.path}:${parsed.check}:${parsed.match}`] : [];
     }));
     for (const [filePath, alerts] of Object.entries(valeOutput)) {
         for (const alert of alerts) {
-            const body = formatComment(alert, filePath);
+            const line = readLine(filePath, alert.Line) ?? "";
+            const body = (0, suggestion_1.formatComment)(alert, line);
             const dedupeKey = `${filePath}:${alert.Check}:${alert.Match}`;
             if (existingKeys.has(dedupeKey)) {
                 continue;

--- a/vale-action/report-vale.js
+++ b/vale-action/report-vale.js
@@ -35,20 +35,63 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = __importStar(require("fs"));
 const COMMENT_MARKER = "<!-- vale-action -->";
-const SEVERITY_EMOJI = {
-    error: "🔴",
-    warning: "🟡",
-    suggestion: "🔵",
+const LINK_TEXT = {
+    "developers.google.com": "Google developer documentation style guide",
+    "grafana.com": "Grafana Writers' Toolkit",
+    "html.spec.whatwg.org": "HTML specification",
+    "docs.aws.amazon.com": "AWS documentation",
 };
-function formatComment(alert) {
-    const emoji = SEVERITY_EMOJI[alert.Severity];
-    const link = alert.Link ? `\n\n[Style guide](${alert.Link})` : "";
-    return `${COMMENT_MARKER}
-${emoji} **${alert.Check}** (${alert.Severity})
-
-${alert.Message.trimEnd()}${link}`;
+function linkText(url) {
+    try {
+        const { hostname } = new URL(url);
+        return LINK_TEXT[hostname] ?? hostname;
+    }
+    catch {
+        return "style guide";
+    }
 }
-module.exports = async ({ context, core, github }) => {
+function buildSuggestion(alert, filePath) {
+    const { Name, Params } = alert.Action;
+    if (Name !== "replace" && Name !== "remove") {
+        return null;
+    }
+    const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+    const line = lines[alert.Line - 1];
+    if (line === undefined) {
+        return null;
+    }
+    const [start, end] = alert.Span;
+    const before = line.slice(0, start - 1);
+    const after = line.slice(end);
+    let corrected;
+    if (Name === "remove") {
+        corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
+    }
+    else {
+        const first = Params?.[0] ?? "";
+        corrected = before + first + after;
+    }
+    let suggestion = "```suggestion\n" + corrected + "\n```";
+    if (Name === "replace" && Params && Params.length > 1) {
+        const alternatives = Params.slice(1)
+            .map((p) => `\`${p}\``)
+            .join(", ");
+        suggestion += `\n\nAlternatives: ${alternatives}`;
+    }
+    return suggestion;
+}
+function formatComment(alert, filePath) {
+    const reference = alert.Link
+        ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
+        : "";
+    const suggestion = buildSuggestion(alert, filePath);
+    const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
+    return `${COMMENT_MARKER}
+**${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${suggestionBlock}${reference}`;
+}
+module.exports = async ({ context, core, github, }) => {
     const raw = fs.readFileSync("vale.json", "utf-8");
     if (!raw.trim()) {
         return;
@@ -72,7 +115,7 @@ module.exports = async ({ context, core, github }) => {
         .map((c) => `${c.path}:${c.line}:${c.body}`));
     for (const [filePath, alerts] of Object.entries(valeOutput)) {
         for (const alert of alerts) {
-            const body = formatComment(alert);
+            const body = formatComment(alert, filePath);
             const dedupeKey = `${filePath}:${alert.Line}:${body}`;
             if (existingKeys.has(dedupeKey)) {
                 continue;

--- a/vale-action/report-vale.ts
+++ b/vale-action/report-vale.ts
@@ -31,7 +31,19 @@ interface ScriptArgs {
   github: InstanceType<typeof GitHub>;
 }
 
-const COMMENT_MARKER = "<!-- vale-action -->";
+function commentMarker(check: string, match: string): string {
+  return `<!-- vale-action check="${check}" match="${match}" -->`;
+}
+
+function parseMarker(
+  body: string,
+): { check: string; match: string } | undefined {
+  const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
+  if (!m) {
+    return undefined;
+  }
+  return { check: m[1], match: m[2] };
+}
 
 const LINK_TEXT: Record<string, string> = {
   "developers.google.com": "Google developer documentation style guide",
@@ -94,10 +106,16 @@ function formatComment(alert: ValeAlert, filePath: string): string {
   const suggestion = buildSuggestion(alert, filePath);
   const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
 
-  return `${COMMENT_MARKER}
+  const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
+  const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
+  const footer =
+    "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
+    ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
+
+  return `${commentMarker(alert.Check, alert.Match)}
 **${alert.Check}** (${alert.Severity})
 
-${alert.Message.trimEnd()}${suggestionBlock}${reference}`;
+${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
 }
 
 module.exports = async ({
@@ -124,23 +142,25 @@ module.exports = async ({
     return;
   }
 
-  const { data: existingComments } =
-    await github.rest.pulls.listReviewComments({
+  const { data: existingComments } = await github.rest.pulls.listReviewComments(
+    {
       owner,
       repo,
       pull_number: pullNumber,
-    });
+    },
+  );
 
   const existingKeys = new Set(
-    existingComments
-      .filter((c: ReviewComment) => c.body.startsWith(COMMENT_MARKER))
-      .map((c: ReviewComment) => `${c.path}:${c.line}:${c.body}`),
+    existingComments.flatMap((c: ReviewComment) => {
+      const parsed = parseMarker(c.body);
+      return parsed ? [`${c.path}:${parsed.check}:${parsed.match}`] : [];
+    }),
   );
 
   for (const [filePath, alerts] of Object.entries(valeOutput)) {
     for (const alert of alerts) {
       const body = formatComment(alert, filePath);
-      const dedupeKey = `${filePath}:${alert.Line}:${body}`;
+      const dedupeKey = `${filePath}:${alert.Check}:${alert.Match}`;
 
       if (existingKeys.has(dedupeKey)) {
         continue;

--- a/vale-action/report-vale.ts
+++ b/vale-action/report-vale.ts
@@ -3,27 +3,16 @@ import type * as Core from "@actions/core";
 import type { GitHub } from "@actions/github/lib/utils";
 import type { Context } from "@actions/github/lib/context";
 import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+import {
+  commentMarker,
+  formatComment,
+  parseMarker,
+  ValeAlert,
+  ValeOutput,
+} from "./suggestion";
 
 type ReviewComment =
   RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][number];
-
-interface ValeAction {
-  Name: "replace" | "remove" | "";
-  Params: string[] | null;
-}
-
-interface ValeAlert {
-  Action: ValeAction;
-  Check: string;
-  Line: number;
-  Link: string;
-  Match: string;
-  Message: string;
-  Severity: "error" | "warning" | "suggestion";
-  Span: [number, number];
-}
-
-type ValeOutput = Record<string, ValeAlert[]>;
 
 interface ScriptArgs {
   context: Context;
@@ -31,91 +20,8 @@ interface ScriptArgs {
   github: InstanceType<typeof GitHub>;
 }
 
-function commentMarker(check: string, match: string): string {
-  return `<!-- vale-action check="${check}" match="${match}" -->`;
-}
-
-function parseMarker(
-  body: string,
-): { check: string; match: string } | undefined {
-  const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
-  if (!m) {
-    return undefined;
-  }
-  return { check: m[1], match: m[2] };
-}
-
-const LINK_TEXT: Record<string, string> = {
-  "developers.google.com": "Google developer documentation style guide",
-  "grafana.com": "Grafana Writers' Toolkit",
-  "html.spec.whatwg.org": "HTML specification",
-  "docs.aws.amazon.com": "AWS documentation",
-};
-
-function linkText(url: string): string {
-  try {
-    const { hostname } = new URL(url);
-    return LINK_TEXT[hostname] ?? hostname;
-  } catch {
-    return "style guide";
-  }
-}
-
-function buildSuggestion(alert: ValeAlert, filePath: string): string | null {
-  const { Name, Params } = alert.Action;
-
-  if (Name !== "replace" && Name !== "remove") {
-    return null;
-  }
-
-  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-  const line = lines[alert.Line - 1];
-  if (line === undefined) {
-    return null;
-  }
-
-  const [start, end] = alert.Span;
-  const before = line.slice(0, start - 1);
-  const after = line.slice(end);
-
-  let corrected: string;
-  if (Name === "remove") {
-    corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
-  } else {
-    const first = Params?.[0] ?? "";
-    corrected = before + first + after;
-  }
-
-  let suggestion = "```suggestion\n" + corrected + "\n```";
-
-  if (Name === "replace" && Params && Params.length > 1) {
-    const alternatives = Params.slice(1)
-      .map((p) => `\`${p}\``)
-      .join(", ");
-    suggestion += `\n\nAlternatives: ${alternatives}`;
-  }
-
-  return suggestion;
-}
-
-function formatComment(alert: ValeAlert, filePath: string): string {
-  const reference = alert.Link
-    ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
-    : "";
-
-  const suggestion = buildSuggestion(alert, filePath);
-  const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
-
-  const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
-  const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
-  const footer =
-    "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
-    ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
-
-  return `${commentMarker(alert.Check, alert.Match)}
-**${alert.Check}** (${alert.Severity})
-
-${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
+function readLine(filePath: string, lineNumber: number): string | undefined {
+  return fs.readFileSync(filePath, "utf-8").split("\n")[lineNumber - 1];
 }
 
 module.exports = async ({
@@ -142,13 +48,12 @@ module.exports = async ({
     return;
   }
 
-  const { data: existingComments } = await github.rest.pulls.listReviewComments(
-    {
+  const { data: existingComments } =
+    await github.rest.pulls.listReviewComments({
       owner,
       repo,
       pull_number: pullNumber,
-    },
-  );
+    });
 
   const existingKeys = new Set(
     existingComments.flatMap((c: ReviewComment) => {
@@ -158,8 +63,9 @@ module.exports = async ({
   );
 
   for (const [filePath, alerts] of Object.entries(valeOutput)) {
-    for (const alert of alerts) {
-      const body = formatComment(alert, filePath);
+    for (const alert of alerts as ValeAlert[]) {
+      const line = readLine(filePath, alert.Line) ?? "";
+      const body = formatComment(alert, line);
       const dedupeKey = `${filePath}:${alert.Check}:${alert.Match}`;
 
       if (existingKeys.has(dedupeKey)) {

--- a/vale-action/report-vale.ts
+++ b/vale-action/report-vale.ts
@@ -7,12 +7,20 @@ import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-meth
 type ReviewComment =
   RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][number];
 
+interface ValeAction {
+  Name: "replace" | "remove" | "";
+  Params: string[] | null;
+}
+
 interface ValeAlert {
+  Action: ValeAction;
   Check: string;
   Line: number;
   Link: string;
+  Match: string;
   Message: string;
   Severity: "error" | "warning" | "suggestion";
+  Span: [number, number];
 }
 
 type ValeOutput = Record<string, ValeAlert[]>;
@@ -25,23 +33,78 @@ interface ScriptArgs {
 
 const COMMENT_MARKER = "<!-- vale-action -->";
 
-const SEVERITY_EMOJI: Record<ValeAlert["Severity"], string> = {
-  error: "🔴",
-  warning: "🟡",
-  suggestion: "🔵",
+const LINK_TEXT: Record<string, string> = {
+  "developers.google.com": "Google developer documentation style guide",
+  "grafana.com": "Grafana Writers' Toolkit",
+  "html.spec.whatwg.org": "HTML specification",
+  "docs.aws.amazon.com": "AWS documentation",
 };
 
-function formatComment(alert: ValeAlert): string {
-  const emoji = SEVERITY_EMOJI[alert.Severity];
-  const link = alert.Link ? `\n\n[Style guide](${alert.Link})` : "";
-
-  return `${COMMENT_MARKER}
-${emoji} **${alert.Check}** (${alert.Severity})
-
-${alert.Message.trimEnd()}${link}`;
+function linkText(url: string): string {
+  try {
+    const { hostname } = new URL(url);
+    return LINK_TEXT[hostname] ?? hostname;
+  } catch {
+    return "style guide";
+  }
 }
 
-module.exports = async ({ context, core, github }: ScriptArgs): Promise<void> => {
+function buildSuggestion(alert: ValeAlert, filePath: string): string | null {
+  const { Name, Params } = alert.Action;
+
+  if (Name !== "replace" && Name !== "remove") {
+    return null;
+  }
+
+  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+  const line = lines[alert.Line - 1];
+  if (line === undefined) {
+    return null;
+  }
+
+  const [start, end] = alert.Span;
+  const before = line.slice(0, start - 1);
+  const after = line.slice(end);
+
+  let corrected: string;
+  if (Name === "remove") {
+    corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
+  } else {
+    const first = Params?.[0] ?? "";
+    corrected = before + first + after;
+  }
+
+  let suggestion = "```suggestion\n" + corrected + "\n```";
+
+  if (Name === "replace" && Params && Params.length > 1) {
+    const alternatives = Params.slice(1)
+      .map((p) => `\`${p}\``)
+      .join(", ");
+    suggestion += `\n\nAlternatives: ${alternatives}`;
+  }
+
+  return suggestion;
+}
+
+function formatComment(alert: ValeAlert, filePath: string): string {
+  const reference = alert.Link
+    ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
+    : "";
+
+  const suggestion = buildSuggestion(alert, filePath);
+  const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
+
+  return `${COMMENT_MARKER}
+**${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${suggestionBlock}${reference}`;
+}
+
+module.exports = async ({
+  context,
+  core,
+  github,
+}: ScriptArgs): Promise<void> => {
   const raw = fs.readFileSync("vale.json", "utf-8");
   if (!raw.trim()) {
     return;
@@ -76,7 +139,7 @@ module.exports = async ({ context, core, github }: ScriptArgs): Promise<void> =>
 
   for (const [filePath, alerts] of Object.entries(valeOutput)) {
     for (const alert of alerts) {
-      const body = formatComment(alert);
+      const body = formatComment(alert, filePath);
       const dedupeKey = `${filePath}:${alert.Line}:${body}`;
 
       if (existingKeys.has(dedupeKey)) {

--- a/vale-action/report-vale.ts
+++ b/vale-action/report-vale.ts
@@ -1,0 +1,104 @@
+import * as fs from "fs";
+import type * as Core from "@actions/core";
+import type { GitHub } from "@actions/github/lib/utils";
+import type { Context } from "@actions/github/lib/context";
+import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+
+type ReviewComment =
+  RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"][number];
+
+interface ValeAlert {
+  Check: string;
+  Line: number;
+  Link: string;
+  Message: string;
+  Severity: "error" | "warning" | "suggestion";
+}
+
+type ValeOutput = Record<string, ValeAlert[]>;
+
+interface ScriptArgs {
+  context: Context;
+  core: typeof Core;
+  github: InstanceType<typeof GitHub>;
+}
+
+const COMMENT_MARKER = "<!-- vale-action -->";
+
+const SEVERITY_EMOJI: Record<ValeAlert["Severity"], string> = {
+  error: "🔴",
+  warning: "🟡",
+  suggestion: "🔵",
+};
+
+function formatComment(alert: ValeAlert): string {
+  const emoji = SEVERITY_EMOJI[alert.Severity];
+  const link = alert.Link ? `\n\n[Style guide](${alert.Link})` : "";
+
+  return `${COMMENT_MARKER}
+${emoji} **${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${link}`;
+}
+
+module.exports = async ({ context, core, github }: ScriptArgs): Promise<void> => {
+  const raw = fs.readFileSync("vale.json", "utf-8");
+  if (!raw.trim()) {
+    return;
+  }
+
+  const valeOutput = JSON.parse(raw) as ValeOutput;
+
+  const { owner, repo } = context.repo;
+  const pullNumber = context.issue.number;
+  const payload = context.payload as {
+    pull_request?: { head?: { sha?: string } };
+  };
+  const commitSha = payload.pull_request?.head?.sha;
+
+  if (!commitSha) {
+    core.setFailed("Could not determine the head commit SHA.");
+    return;
+  }
+
+  const { data: existingComments } =
+    await github.rest.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+
+  const existingKeys = new Set(
+    existingComments
+      .filter((c: ReviewComment) => c.body.startsWith(COMMENT_MARKER))
+      .map((c: ReviewComment) => `${c.path}:${c.line}:${c.body}`),
+  );
+
+  for (const [filePath, alerts] of Object.entries(valeOutput)) {
+    for (const alert of alerts) {
+      const body = formatComment(alert);
+      const dedupeKey = `${filePath}:${alert.Line}:${body}`;
+
+      if (existingKeys.has(dedupeKey)) {
+        continue;
+      }
+
+      try {
+        await github.rest.pulls.createReviewComment({
+          owner,
+          repo,
+          pull_number: pullNumber,
+          commit_id: commitSha,
+          path: filePath,
+          line: alert.Line,
+          body,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        core.warning(
+          `Could not post comment on ${filePath}:${alert.Line}: ${message}`,
+        );
+      }
+    }
+  }
+};

--- a/vale-action/suggestion.js
+++ b/vale-action/suggestion.js
@@ -1,0 +1,81 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.commentMarker = commentMarker;
+exports.parseMarker = parseMarker;
+exports.linkText = linkText;
+exports.applySuggestion = applySuggestion;
+exports.formatComment = formatComment;
+const LINK_TEXT = {
+    "developers.google.com": "Google developer documentation style guide",
+    "grafana.com": "Grafana Writers' Toolkit",
+    "html.spec.whatwg.org": "HTML specification",
+    "docs.aws.amazon.com": "AWS documentation",
+};
+function commentMarker(check, match) {
+    return `<!-- vale-action check="${check}" match="${match}" -->`;
+}
+function parseMarker(body) {
+    const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
+    if (!m) {
+        return undefined;
+    }
+    return { check: m[1], match: m[2] };
+}
+function linkText(url) {
+    try {
+        const { hostname } = new URL(url);
+        return LINK_TEXT[hostname] ?? hostname;
+    }
+    catch {
+        return "style guide";
+    }
+}
+function applySuggestion(alert, line) {
+    const { Name, Params } = alert.Action;
+    if (Name !== "replace" && Name !== "remove") {
+        return null;
+    }
+    const [start, end] = alert.Span;
+    const before = line.slice(0, start - 1);
+    const after = line.slice(end);
+    let corrected;
+    if (Name === "remove") {
+        corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
+    }
+    else {
+        const first = Params?.[0] ?? "";
+        let rest = after;
+        if (alert.Check === "Grafana.Latin" &&
+            rest.startsWith(".") &&
+            !rest.startsWith("..")) {
+            rest = rest.slice(1);
+            if (rest.startsWith(" ") && !rest.startsWith(", ")) {
+                rest = "," + rest;
+            }
+        }
+        corrected = before + first + rest;
+    }
+    let suggestion = "```suggestion\n" + corrected + "\n```";
+    if (Name === "replace" && Params && Params.length > 1) {
+        const alternatives = Params.slice(1)
+            .map((p) => `\`${p}\``)
+            .join(", ");
+        suggestion += `\n\nAlternatives: ${alternatives}`;
+    }
+    return suggestion;
+}
+function formatComment(alert, line) {
+    const reference = alert.Link
+        ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
+        : "";
+    const suggestion = applySuggestion(alert, line);
+    const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
+    const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
+    const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
+    const footer = "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
+        ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
+    return `${commentMarker(alert.Check, alert.Match)}
+**${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
+}

--- a/vale-action/suggestion.test.ts
+++ b/vale-action/suggestion.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applySuggestion, ValeAlert } from "./suggestion";
+
+function makeAlert(
+  check: string,
+  actionName: "replace" | "remove" | "",
+  params: string[] | null,
+  match: string,
+  span: [number, number],
+): ValeAlert {
+  return {
+    Action: { Name: actionName, Params: params },
+    Check: check,
+    Line: 1,
+    Link: "",
+    Match: match,
+    Message: "",
+    Severity: "warning",
+    Span: span,
+  };
+}
+
+describe("applySuggestion", () => {
+  describe("Grafana.Latin", () => {
+    it("replaces e.g. mid-sentence and adds a comma", () => {
+      const alert = makeAlert("Grafana.Latin", "replace", ["for example"], "e.g", [9, 11]);
+      assert.equal(
+        applySuggestion(alert, "foo bar e.g. baz"),
+        "```suggestion\nfoo bar for example, baz\n```",
+      );
+    });
+
+    it("does not add a comma when one already follows", () => {
+      const alert = makeAlert("Grafana.Latin", "replace", ["for example"], "e.g", [9, 11]);
+      assert.equal(
+        applySuggestion(alert, "foo bar e.g., baz"),
+        "```suggestion\nfoo bar for example, baz\n```",
+      );
+    });
+
+    it("does not add a comma when e.g. ends the sentence", () => {
+      const alert = makeAlert("Grafana.Latin", "replace", ["for example"], "e.g", [5, 7]);
+      assert.equal(
+        applySuggestion(alert, "See e.g."),
+        "```suggestion\nSee for example\n```",
+      );
+    });
+
+    it("replaces i.e. mid-sentence and adds a comma", () => {
+      const alert = makeAlert("Grafana.Latin", "replace", ["that is"], "i.e", [5, 7]);
+      assert.equal(
+        applySuggestion(alert, "foo i.e. bar"),
+        "```suggestion\nfoo that is, bar\n```",
+      );
+    });
+  });
+
+  describe("replace action", () => {
+    it("replaces a word without adding a comma", () => {
+      const alert = makeAlert("Grafana.Admin", "replace", ["administrator"], "admin", [9, 13]);
+      assert.equal(
+        applySuggestion(alert, "Contact admin for help."),
+        "```suggestion\nContact administrator for help.\n```",
+      );
+    });
+
+    it("preserves a sentence-ending period after a plain word replacement", () => {
+      const alert = makeAlert("Grafana.SelfManaged", "replace", ["self-managed"], "on-prem", [5, 11]);
+      assert.equal(
+        applySuggestion(alert, "Use on-prem."),
+        "```suggestion\nUse self-managed.\n```",
+      );
+    });
+
+    it("uses the first param as the suggestion and lists alternatives", () => {
+      const alert = makeAlert("Grafana.AllowsTo", "replace", ["allows you to", "makes it possible to"], "allows to", [6, 14]);
+      assert.equal(
+        applySuggestion(alert, "This allows to configure it."),
+        "```suggestion\nThis allows you to configure it.\n```\n\nAlternatives: `makes it possible to`",
+      );
+    });
+
+    it("returns null when there is no action", () => {
+      const alert = makeAlert("Grafana.AltText", "", null, "", [1, 1]);
+      assert.equal(applySuggestion(alert, "![](image.png)"), null);
+    });
+  });
+
+  describe("remove action", () => {
+    it("removes the matched word and collapses the double space", () => {
+      const alert = makeAlert("Grafana.Simple", "remove", null, "simply", [4, 9]);
+      assert.equal(
+        applySuggestion(alert, "It simply works."),
+        "```suggestion\nIt works.\n```",
+      );
+    });
+  });
+});

--- a/vale-action/suggestion.ts
+++ b/vale-action/suggestion.ts
@@ -1,0 +1,111 @@
+export interface ValeAction {
+  Name: "replace" | "remove" | "";
+  Params: string[] | null;
+}
+
+export interface ValeAlert {
+  Action: ValeAction;
+  Check: string;
+  Line: number;
+  Link: string;
+  Match: string;
+  Message: string;
+  Severity: "error" | "warning" | "suggestion";
+  Span: [number, number];
+}
+
+export type ValeOutput = Record<string, ValeAlert[]>;
+
+const LINK_TEXT: Record<string, string> = {
+  "developers.google.com": "Google developer documentation style guide",
+  "grafana.com": "Grafana Writers' Toolkit",
+  "html.spec.whatwg.org": "HTML specification",
+  "docs.aws.amazon.com": "AWS documentation",
+};
+
+export function commentMarker(check: string, match: string): string {
+  return `<!-- vale-action check="${check}" match="${match}" -->`;
+}
+
+export function parseMarker(
+  body: string,
+): { check: string; match: string } | undefined {
+  const m = body.match(/<!-- vale-action check="([^"]*)" match="([^"]*)" -->/);
+  if (!m) {
+    return undefined;
+  }
+  return { check: m[1], match: m[2] };
+}
+
+export function linkText(url: string): string {
+  try {
+    const { hostname } = new URL(url);
+    return LINK_TEXT[hostname] ?? hostname;
+  } catch {
+    return "style guide";
+  }
+}
+
+export function applySuggestion(alert: ValeAlert, line: string): string | null {
+  const { Name, Params } = alert.Action;
+
+  if (Name !== "replace" && Name !== "remove") {
+    return null;
+  }
+
+  const [start, end] = alert.Span;
+  const before = line.slice(0, start - 1);
+  const after = line.slice(end);
+
+  let corrected: string;
+  if (Name === "remove") {
+    corrected = (before + after).replace(/ {2,}/g, " ").trimEnd();
+  } else {
+    const first = Params?.[0] ?? "";
+    let rest = after;
+
+    if (
+      alert.Check === "Grafana.Latin" &&
+      rest.startsWith(".") &&
+      !rest.startsWith("..")
+    ) {
+      rest = rest.slice(1);
+      if (rest.startsWith(" ") && !rest.startsWith(", ")) {
+        rest = "," + rest;
+      }
+    }
+
+    corrected = before + first + rest;
+  }
+
+  let suggestion = "```suggestion\n" + corrected + "\n```";
+
+  if (Name === "replace" && Params && Params.length > 1) {
+    const alternatives = Params.slice(1)
+      .map((p) => `\`${p}\``)
+      .join(", ");
+    suggestion += `\n\nAlternatives: ${alternatives}`;
+  }
+
+  return suggestion;
+}
+
+export function formatComment(alert: ValeAlert, line: string): string {
+  const reference = alert.Link
+    ? `\n\nFor more information, refer to [${linkText(alert.Link)}](${alert.Link}).`
+    : "";
+
+  const suggestion = applySuggestion(alert, line);
+  const suggestionBlock = suggestion ? `\n\n${suggestion}` : "";
+
+  const issueTitle = encodeURIComponent(`Vale rule: ${alert.Check}`);
+  const issueUrl = `https://github.com/grafana/writers-toolkit/issues/new?title=${issueTitle}`;
+  const footer =
+    "\n\n---\n_Reported by Vale using Grafana Writers' Toolkit style." +
+    ` If you believe we can improve the rule, [report an issue](${issueUrl})._`;
+
+  return `${commentMarker(alert.Check, alert.Match)}
+**${alert.Check}** (${alert.Severity})
+
+${alert.Message.trimEnd()}${suggestionBlock}${reference}${footer}`;
+}

--- a/vale-action/tsconfig.json
+++ b/vale-action/tsconfig.json
@@ -10,6 +10,6 @@
     "strict": true,
     "target": "es2022"
   },
-  "include": ["report-vale.ts"],
-  "exclude": ["node_modules"]
+  "include": ["report-vale.ts", "suggestion.ts"],
+  "exclude": ["node_modules", "*.test.ts"]
 }

--- a/vale-action/tsconfig.json
+++ b/vale-action/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": ".",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2022"
+  },
+  "include": ["report-vale.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vale/Grafana/styles/Grafana/AltText.yml
+++ b/vale/Grafana/styles/Grafana/AltText.yml
@@ -1,5 +1,10 @@
 extends: script
-message: All images must have alt text.
+message: |
+  Add alt text to this image.
+
+  Alt text describes the image content for readers using screen readers, improves SEO, and displays when the image fails to load.
+  Write the alt text between the square brackets: ![Descriptive alt text here](image-path).
+  Describe what the image shows, not what it is. For example, write 'Graph showing CPU usage spiking at 14:00' rather than 'CPU graph'.
 link: https://grafana.com/docs/writers-toolkit/write/image-guidelines/#alt-text
 scope: raw
 script: |

--- a/vale/Grafana/styles/Grafana/Exclamation.yml
+++ b/vale/Grafana/styles/Grafana/Exclamation.yml
@@ -3,7 +3,10 @@ action:
 extends: existence
 level: warning
 link: https://developers.google.com/style/tone#some-things-to-avoid-where-possible
-message: Avoid exclamation points in text, except in rare really exciting moments.
+message: |
+  Remove the exclamation point.
+
+  Exclamation points make technical documentation feel informal and hyperbolic.
 nonword: true
 tokens:
   - "\\w+!(?:\\s|$)"

--- a/vale/Grafana/styles/Grafana/Latin.yml
+++ b/vale/Grafana/styles/Grafana/Latin.yml
@@ -4,7 +4,11 @@ extends: substitution
 ignorecase: true
 level: error
 link: https://developers.google.com/style/abbreviations#dont-use
-message: Use '%s' instead of '%s'.
+message: |
+  Use '%s' instead of '%s'.
+
+  Latin abbreviations such as 'e.g.' and 'i.e.' are easily confused with each other and with other abbreviations.
+  Spelling them out improves clarity, especially for readers who aren't native English speakers.
 swap:
   'e\.?g[,.]?': for example
   'i\.?e[,.]?': that is

--- a/vale/Grafana/styles/Grafana/Ordinal.yml
+++ b/vale/Grafana/styles/Grafana/Ordinal.yml
@@ -1,7 +1,11 @@
 extends: existence
 level: error
 link: https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#numbers
-message: For ordinals, write out first through ninth. For 10th on, use numerals.
+message: |
+  Replace this numeral ordinal with a word.
+
+  Write out ordinals from first through ninth as words, and use numerals from 10th onward.
+  For example, use 'first', 'second', and 'third', not '1st', '2nd', and '3rd'.
 tokens:
   - 1st
   - 2nd

--- a/vale/Grafana/styles/Grafana/Parentheses.yml
+++ b/vale/Grafana/styles/Grafana/Parentheses.yml
@@ -1,11 +1,13 @@
 extends: existence
 level: suggestion
 link: https://developers.google.com/style/parentheses
-message: Use parentheses judiciously.
+message: |
+  Consider rewriting to avoid parentheses.
 
+  Parenthetical content often indicates a sentence that can be restructured for clarity.
+  If the content is important enough to include, integrate it into the sentence.
+  If it's not important, remove it.
 nonword: true
 
 tokens:
-  # Allow for single characters in backticks.
-  # For example, don't use single asterisks (`*`).
   - "\\(.{4,}\\)"

--- a/vale/Grafana/styles/Grafana/Please.yml
+++ b/vale/Grafana/styles/Grafana/Please.yml
@@ -1,5 +1,9 @@
 extends: existence
-message: "It's great to be polite, but using 'please' in a set of instructions is overdoing the politeness."
+message: |
+  Remove 'please' from instructions.
+
+  Direct imperative sentences are clearer and more appropriate in technical documentation.
+  Excessive politeness reads as filler and adds length without improving comprehension.
 level: error
 link: https://developers.google.com/style/tone#politeness
 ignorecase: true

--- a/vale/Grafana/styles/Grafana/RepeatedWords.yml
+++ b/vale/Grafana/styles/Grafana/RepeatedWords.yml
@@ -1,5 +1,8 @@
 extends: repetition
-message: "'%s' is repeated"
+message: |
+  '%s' is repeated.
+
+  Remove the duplicate word.
 level: error
 alpha: true
 tokens:

--- a/vale/Grafana/styles/Grafana/Shortcodes.yml
+++ b/vale/Grafana/styles/Grafana/Shortcodes.yml
@@ -1,6 +1,6 @@
 extends: script
 message: |
-  Prefer `{{<` and `>}}` instead of `{{%` and `%}}`
+  Use `{{<` and `>}}` delimiters instead of `{{%` and `%}}` for admonition shortcodes.
 
   It has the most consistent semantics.
 

--- a/vale/Grafana/styles/Grafana/Spelling.yml
+++ b/vale/Grafana/styles/Grafana/Spelling.yml
@@ -1,17 +1,13 @@
 extends: spelling
 message: |
-  Did you really mean '%s'?
+  '%s' is not in the Grafana dictionary.
 
-  The Grafana dictionary might not know of this word yet.
-
-  To add a new word, refer to [Add words to the Grafana Labs dictionary](https://grafana.com/docs/writers-toolkit/review/lint-prose/dictionary/add-words/).
+  If the word is correct, add it to the dictionary by following [Add words to the Grafana Labs dictionary](https://grafana.com/docs/writers-toolkit/review/lint-prose/dictionary/add-words/).
   Alternatively, raise an [issue](https://github.com/grafana/writers-toolkit/issues/new?title=Grafana.Spelling%%3A%%20%[1]s) and a maintainer will add it for you.
 
-  For UI elements, use [bold formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
-  The spell checker doesn't check words with bold formatting.
-
-  For paths; configuration; user input; code; class, method, and variable names; statuscodes; and console output, use [code formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
-  The spell checker doesn't check words with code formatting.
+  The spell checker ignores words in the following formatting:
+  - [Bold](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold) — use for UI elements.
+  - [Code](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#code-font) — use for paths, configuration, user input, code, class, method, and variable names, status codes, and console output.
 level: error
 append: true
 dicpath: config/dictionaries

--- a/vale/Grafana/styles/Grafana/Wish.yml
+++ b/vale/Grafana/styles/Grafana/Wish.yml
@@ -1,8 +1,11 @@
 extends: substitution
 level: warning
 link: https://developers.google.com/style/word-list#wish
-message: Use '%s' instead of '%s'.
+message: |
+  Use '%s' instead of '%s'.
 
+  'Wish' is informal and vague in technical writing.
+  Use 'need' when the reader requires something to proceed, or 'want' when describing an optional goal.
 ignorecase: false
 
 action:

--- a/vale/Grafana/styles/Grafana/WordList.yml
+++ b/vale/Grafana/styles/Grafana/WordList.yml
@@ -4,7 +4,11 @@
 "ignorecase": false
 "level": "warning"
 "link": "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/"
-"message": "Use '%s' instead of '%s'."
+"message": |
+  Use '%s' instead of '%s'.
+
+  This word or phrase is not consistent with the Grafana style guide word list.
+  Refer to the style guide for the full list of preferred terms and their rationale.
 "swap":
   "(?:(?<!Data )Firehose|Kinesis Data Firehose|Kinesis Firehose)": "Data Firehose"
   "(?:SHA-1|HAS-SHA1)": "SHA-1"


### PR DESCRIPTION
The use of codeql seems nice because it has alert tracking over time and handles the comments for us.

However, we don't check for dismissed rules, causing the CI to fail but without any PR feedback.
It also gets reported as a "security" error and that's definitely not the case.

This gives us more control over the comment body, let's us include suggestions, and doesn't have the confusing mismatch.