### PR TITLE
Expose source reference as a parameter

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -49,6 +49,10 @@ on:
             description: The path to mount the documentation in the website content structure. For example, "content/docs/mimir/latest".
             required: true
             type: string
+          ref:
+            description: Optional git ref to check out for this source. If omitted, the workflow checks out the caller PR branch.
+            required: false
+            type: string
 
           The following example mounts both the Mimir documentation and the mimir-distributed Helm chart documentation:
 
@@ -65,7 +69,8 @@ on:
               "relative_prefix": "/docs/helm-charts/mimir-distributed/latest/",
               "repo": "mimir",
               "source_directory": "docs/sources/mimir-distributed",
-              "website_directory": "content/docs/helm-charts/mimir-distributed/latest"
+              "website_directory": "content/docs/helm-charts/mimir-distributed/latest",
+              "ref": "main"
             }
           ]
         type: string

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -55,10 +55,23 @@ else
     exit 1
   fi
 
+  function checkout_directory {
+    local repo=$1
+    local ref=$2
+    local sanitized_ref="${ref//[^A-Za-z0-9._-]/_}"
+
+    if [[ -z "${ref}" ]]; then
+      echo "src/${repo}"
+    else
+      echo "src/${repo}__${sanitized_ref}"
+    fi
+  }
+
   # Clone a repository to a specific directory.
   function clone {
     local repo=$1
-    local directory=$2
+    local ref=$2
+    local directory=$3
 
     if [[ -d "${directory}" ]]; then
       echo "Directory ${directory} already exists, skipping clone"
@@ -67,7 +80,19 @@ else
     fi
 
     gh repo clone "grafana/${repo}" "${directory}"
-    (cd "${directory}" && gh pr checkout "${BRANCH}")
+    if [[ -z "${ref}" ]]; then
+      (cd "${directory}" && gh pr checkout "${BRANCH}")
+    else
+      (
+        cd "${directory}"
+        if git checkout "${ref}" >/dev/null 2>&1; then
+          :
+        else
+          git fetch origin "${ref}"
+          git checkout FETCH_HEAD
+        fi
+      )
+    fi
   }
 
   # Find the highest semantic version directory in a given path
@@ -142,15 +167,20 @@ else
 
   # Check out all the source repositories defined in SOURCES.
   function check_out_sources {
+    declare -A seen=()
     index_files=()
-    while read -r repo; do
+    while IFS=$'\t' read -r repo ref; do
       if [[ -z "${repo}" ]]; then
         continue
       fi
 
-      clone "${repo}" "src/${repo}"
-
-    done < <(jq -r '.[].repo' <<<"${SOURCES}")
+      directory="$(checkout_directory "${repo}" "${ref}")"
+      if [[ -n "${seen[${directory}]+x}" ]]; then
+        continue
+      fi
+      seen["${directory}"]=1
+      clone "${repo}" "${ref}" "${directory}"
+    done < <(jq -r '.[] | [(.repo // ""), (.ref // "")] | @tsv' <<<"${SOURCES}")
   }
 
   # Create an entrypoint script for the container.
@@ -207,11 +237,12 @@ EOSCRIPT
   # Add mounts to the volumes variable.
   function configure_volumes {
     volumes=("--volume=${PWD}/dist:/hugo/dist" "--volume=${tempfile}:/entrypoint:z")
-    while read -r repo source_directory website_directory; do
+    while IFS=$'\t' read -r repo ref source_directory website_directory; do
+      directory="$(checkout_directory "${repo}" "${ref}")"
       # Resolve <LATEST> placeholder in source_directory
-      resolved_source_directory=$(resolve_latest_placeholder "${source_directory}" "${PWD}/src/${repo}")
-      volumes+=("--volume=${PWD}/src/${repo}/${resolved_source_directory}:/hugo/${website_directory}:z")
-    done < <(jq -r '.[] | "\(.repo) \(.source_directory) \(.website_directory)"' <<<"${SOURCES}")
+      resolved_source_directory=$(resolve_latest_placeholder "${source_directory}" "${PWD}/${directory}")
+      volumes+=("--volume=${PWD}/${directory}/${resolved_source_directory}:/hugo/${website_directory}:z")
+    done < <(jq -r '.[] | [(.repo // ""), (.ref // ""), (.source_directory // ""), (.website_directory // "")] | @tsv' <<<"${SOURCES}")
   }
 
   # Prepare the command to run the container.


### PR DESCRIPTION
Let's me build deploy previews which use `main` of `grafana/grafana` when building deploy previews like https://github.com/grafana/gcx/pull/704 which is mounted into that content

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
