### PR TITLE
Add async word to the dictionary

### DIFF
--- a/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
+++ b/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-404
+405
 ACL/S po:noun
 actionability/ po:noun
 ADOT/ po:noun
@@ -20,6 +20,7 @@ API/S po:noun
 APT/ po:noun
 ARN/S po:noun
 Asserts/ po:noun
+async/ po:adjective
 Atlassian/ po:noun
 autoscale/DGS po:verb
 autoscaler/S po:noun

--- a/vale/dictionary/a.jsonnet
+++ b/vale/dictionary/a.jsonnet
@@ -21,6 +21,7 @@ local word = import './word.jsonnet';
   word.new('APT', '', 'noun') { abbreviation: true, description: 'https://en.wikipedia.org/wiki/APT_(software)', elaboration: 'Advanced package tool', established_abbreviation: true },
   word.new('ARN', 'S', 'noun') { Amazon: true, abbreviation: true, description: 'Amazon Resource Name', established_abbreviation: true, product: true },
   word.new('Asserts', '', 'noun') { description: 'https://grafana.com/products/cloud/asserts/', product: true },
+  word.new('async', '', 'adjective') { description: 'Short for asynchronous' },
   word.new('Atlassian', '', 'noun') { product: true },
   word.new('autoscale', 'DGS', 'verb'),
   word.new('autoscaler', 'S', 'noun'),


### PR DESCRIPTION
Adding `async` after the bot suggested it [here](https://github.com/grafana/grafana/pull/124938#discussion_r3243629312) 

- [ ] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
