### PR TITLE
feat(vale): add 'Bring Your Own Cloud' to Headings exceptions

### DIFF
--- a/vale/Headings.jsonnet
+++ b/vale/Headings.jsonnet
@@ -6,6 +6,7 @@ local static_exceptions = [
   'AzureAD',
   'Beyla',
   'BoltDB',
+  'Bring Your Own Cloud',
   'CLI',
   'Cloud Logs',
   'Cloud Metrics',


### PR DESCRIPTION
Adds `Bring Your Own Cloud` to the static exceptions list in `vale/Headings.jsonnet` so that headings containing the product term aren't flagged for sentence-style capitalization.

The `Grafana.Headings` rule warns on a heading like `BYOC (Bring Your Own Cloud)` because "Bring Your Own Cloud" is title-cased. It's an established Grafana Cloud product term, so it should be treated as a correctly-cased multi-word exception.

## Relates

- grafana/website#31131
