### PR TITLE
Add agentic and Agentic testing to Grafana dictionary

### DIFF
--- a/vale/Grafana/styles/Grafana/Headings.yml
+++ b/vale/Grafana/styles/Grafana/Headings.yml
@@ -11,6 +11,7 @@
   - "ADOT"
   - "AI Observability"
   - "Agent"
+  - "Agentic testing"
   - "Alloy"
   - "Apollo"
   - "ARN"

--- a/vale/Grafana/styles/Grafana/ProductPossessives.yml
+++ b/vale/Grafana/styles/Grafana/ProductPossessives.yml
@@ -8,6 +8,7 @@
   - "ADOT's"
   - "AI Observability's"
   - "Agent's"
+  - "Agentic testing's"
   - "Alloy's"
   - "Apollo's"
   - "ARN's"

--- a/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
+++ b/vale/Grafana/styles/config/dictionaries/en_US-grafana.dic
@@ -1,4 +1,4 @@
-404
+406
 ACL/S po:noun
 actionability/ po:noun
 ADOT/ po:noun
@@ -7,6 +7,8 @@ Adaptive Metrics/ po:noun
 Aerospike/ po:noun
 after/ po:preposition
 Agent/ po:noun
+agentic/ po:adjective
+Agentic testing/ po:noun
 Alertmanager/MS po:noun
 allowlist/DGS po:verb
 allowlist/S po:noun

--- a/vale/dictionary/a.jsonnet
+++ b/vale/dictionary/a.jsonnet
@@ -8,6 +8,8 @@ local word = import './word.jsonnet';
   word.new('Aerospike', '', 'noun'),
   word.new('after', '', 'preposition') { swaps: { Once: 'After' } },
   word.new('Agent', '', 'noun') { product: true },
+  word.new('agentic', '', 'adjective') { description: 'Relating to AI agents that act autonomously to accomplish tasks.' },
+  word.new('Agentic testing', '', 'noun') { description: 'Grafana Cloud feature for creating functional browser tests from plain-language user journeys.', product: true },
   word.new('Alertmanager', 'MS', 'noun') { swaps: { '(?:alert[Mm]anager|[Aa]lert [Mm]anager|AlertManager)': 'Alertmanager' } },
   word.new('allowlist', 'DGS', 'verb') { swaps: { whitelisted: 'allowlisted', whitelisting: 'allowlisting', whitelists: 'allowlists' } },
   word.new('allowlist', 'S', 'noun') { swaps: { whitelist: 'allowlist' } },


### PR DESCRIPTION
## Summary
- Adds `agentic` as an adjective to the Grafana Labs dictionary to resolve `Grafana.Spelling` Vale errors in documentation that uses the term.
- Adds `Agentic testing` as a Grafana Cloud product name for heading capitalization and possessive rules.

This supports [grafana/website#31117](https://github.com/grafana/website/pull/31117), which documents the Agentic testing feature.

## Test plan
- [ ] Verify `en_US-grafana.dic` includes `agentic/` and `Agentic testing/`
- [ ] After merge and Vale image update, confirm website PR #31117 passes `Grafana.Spelling` checks


Made with [Cursor](https://cursor.com)