### PR TITLE
Push to GAR mirror instead of Docker Hub to publish grafana/vale image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - id: push-to-gar-mirror
-        uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
+        uses: grafana/shared-workflows/actions/docker-build-push-image@c66d74df41cf4ed28a90da1d91c263f9d1609a21 # docker-build-push-image/v0.3.4
         with:
           context: vale
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,14 +21,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: push-to-dockerhub
+      - id: push-to-gar-mirror
         uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         with:
           context: vale
           platforms: linux/amd64,linux/arm64
           push: true
-          dockerhub-repository: grafana/vale
-          registries: dockerhub
+          registries: gar
+          gar-environment: prod
+          gar-image: vale
+          gar-repository: dockerhub-writers-toolkit-prod-mirror
           tags: |-
             ${{ github.sha }}
             latest


### PR DESCRIPTION
Needed https://github.com/grafana/deployment_tools/pull/626741.

Fixes the problems with publishing new images since infrastructure mandated the use of mirroring.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

Closes #1443
