### PR TITLE
Fix token matching for Hugo shortcodes missing post-argument whitespace

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,4 +2,5 @@ MinAlertLevel = warning
 Packages = Google, https://github.com/errata-ai/Hugo/releases/download/v0.2.0/Hugo.zip, Readability, vale/Grafana
 [*.md]
 BasedOnStyles = Grafana
-TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*, \
+({{<[^\n]+?>}}|{{%[^\n]+?%}})

--- a/vale/.vale.ini
+++ b/vale/.vale.ini
@@ -3,4 +3,5 @@ Packages = Grafana, https://github.com/errata-ai/Hugo/releases/download/v0.2.0/H
 
 [*]
 BasedOnStyles = Grafana
-TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
+TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*, \
+({{<[^\n]+?>}}|{{%[^\n]+?%}})


### PR DESCRIPTION
Extends TokenIgnores to also ignore Hugo shortcodes like `{{< figure src="..." alt="...">}}` that omit the space before the closing delimiter.