### PR TITLE
Docs CI: Use Node 24

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -90,7 +90,7 @@ jobs:
           version: 11.5.3
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
       - env:
           DIRECTORY: ${{ inputs.prettier-directory }}
         run: |


### PR DESCRIPTION
When running prettier, we're getting this error:
```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
warn: Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
node:internal/modules/cjs/loader:1031
      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
            ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
    at Module._load (node:internal/modules/cjs/loader:1031:13)
    at Module.require (node:internal/modules/cjs/loader:1289:19)
    at require (node:internal/modules/helpers:182:18)
    at ../store/index/lib/index.js (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:54998:25)
    at __init (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:15:56)
    at ../resolving/npm-resolver/lib/index.js (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:65888:5)
    at __init (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:15:56)
    at ../workspace/projects-graph/lib/index.js (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:66026:5)
    at __init (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:15:56)
    at ../workspace/projects-filter/lib/index.js (file:///home/runner/setup-pnpm/node_modules/.bin/store/v11/links/@/pnpm/11.5.3/cfcc2ab29674b08d865f70f1b415336a766abba7472e8b031ce78b4d80505471/node_modules/pnpm/dist/pnpm.mjs:73445:5) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}

Node.js v20.20.2
```

<!--
Thank you for contributing to Writers' Toolkit!

Consider the following checklist to make sure your PR is most effective.
-->

- [ ] I've used a relevant pull request (PR) title.
- [ ] I've added a link to any relevant issues in the PR description.
- [ ] I've checked my changes on the deploy preview and they look good.
- [ ] I've added an entry to the [What's new](https://github.com/grafana/writers-toolkit/blob/main/docs/sources/whats-new.md) page (only required for notable changes).
