### PR TITLE
Harden interactive-tutorials preview against missing website.yaml trailing newlines

### DIFF
--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -44,7 +44,15 @@ write_page() {
   mkdir -p "$(dirname "${out}")"
   {
     echo "---"
-    [[ -f "${website_yaml}" ]] && cat "${website_yaml}"
+    # website.yaml is concatenated into Hugo front matter, then this script appends
+    # type/title/description. Guarantee a newline after cat so a missing EOF newline
+    # cannot merge the last YAML line with "type: docs" (Hugo: mapping values are
+    # not allowed). An extra blank line is harmless when the file already ends in \n.
+    # See grafana/interactive-tutorials#453 and #419.
+    if [[ -f "${website_yaml}" ]]; then
+      cat "${website_yaml}"
+      echo
+    fi
     echo "type: docs"
     echo "title: ${title}"
     echo "description: ${description}"

--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -44,11 +44,8 @@ write_page() {
   mkdir -p "$(dirname "${out}")"
   {
     echo "---"
-    # website.yaml is concatenated into Hugo front matter, then this script appends
-    # type/title/description. Guarantee a newline after cat so a missing EOF newline
-    # cannot merge the last YAML line with "type: docs" (Hugo: mapping values are
-    # not allowed). An extra blank line is harmless when the file already ends in \n.
-    # See grafana/interactive-tutorials#453 and #419.
+    # Guarantee a newline after cat so a missing EOF newline doesn't break Hugo builds when the delimiter isn't on its own line.
+    # An extra blank line is harmless when the file already ends in one.
     if [[ -f "${website_yaml}" ]]; then
       cat "${website_yaml}"
       echo


### PR DESCRIPTION
## Summary

Defense-in-depth for interactive-tutorials deploy previews: after `cat`-ing `website.yaml` into Hugo front matter, always emit a newline before appending `type` / `title` / `description`.

Without this, a `website.yaml` missing a final newline merges its last line with `type: docs`, and Hugo fails with `mapping values are not allowed in this context`. That has broken unrelated LP PR previews (for example grafana/interactive-tutorials#453 and #419).

Author-side prevention stays in interactive-tutorials (packaging CI on grafana/interactive-tutorials#434). This change only hardens the build script so a bad file cannot take down the preview.

cc @Eve832 — you fixed the same class of breakage in interactive-tutorials#453; FYI this is the writers-toolkit safety net so it does not recur at preview time.

## Test plan

- [ ] Locally simulate `write_page` with and without trailing newline on `website.yaml`; both produce valid YAML front matter
- [ ] After merge, confirm an interactive-tutorials PR preview still builds


Made with [Cursor](https://cursor.com)