### PR TITLE
Limit deploy previews to mounted docs roots

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -126,10 +126,17 @@ jobs:
       website_directory: ${{ steps.preview-paths.outputs.website_directory != '' && steps.preview-paths.outputs.website_directory || env.WEBSITE_DIRECTORY }}
     permissions:
       contents: read # Clone repositories.
+      id-token: write # Log in to GAR to pull development docs-base images.
       pull-requests: read # `gh pr checkout` in deploy-preview/build queries the pullRequests GraphQL API.
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     steps:
+      - name: Log in to GAR
+        if: startsWith(inputs.image, 'us-docker.pkg.dev/')
+        uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
+        with:
+          registry: us-docker.pkg.dev
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: inputs.website_directory
         with:

--- a/deploy-preview/Dockerfile
+++ b/deploy-preview/Dockerfile
@@ -8,4 +8,8 @@ RUN rm -rf /etc/nginx/sites-enabled && \
 COPY deploy-preview-files/deploy-preview/nginx.conf /etc/nginx/nginx.conf
 COPY build.conf /etc/nginx/build.conf
 
+# The build script writes redirect rewrites into dist. Ensure the include
+# target exists even when the build script predates redirects generation.
+RUN touch /usr/share/nginx/dist/preview-redirects.conf
+
 RUN nginx -t

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -51,14 +51,6 @@ EOF
 fi
 cat "/hugo/content/docs/${REPO}/_index.md"
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
-
-# Generate nginx rewrites for the preview server from the Hugo redirects
-# manifest. Older docs-base images have a redirects binary without the
-# --manifest option, so fall back to scraping dist for alias pages.
-touch dist/preview-redirects.conf
-redirects --base-url "" --manifest dist/redirects.txt dist dist/preview-redirects.conf \
-  || redirects --base-url "" dist dist/preview-redirects.conf \
-  || true
 '
 # End legacy input.
 else
@@ -287,82 +279,7 @@ if [[ "${#mounted_docs_roots[@]}" -gt 0 ]]; then
   done
 fi
 
-fallback_title() {
-  local value="\${1//[-_]/ }"
-  local token=""
-  local titled=""
-
-  for token in \${value}; do
-    titled+="\${token^} "
-  done
-
-  echo "\${titled% }"
-}
-
-# Ensure mounted docs roots always have index metadata with titles.
-for docs_dir in /hugo/content/docs/*; do
-  if [[ ! -d "\${docs_dir}" ]]; then
-    continue
-  fi
-
-  index="\${docs_dir}/_index.md"
-  title="$(fallback_title "\${docs_dir##*/}")"
-
-  if [[ ! -f "\${index}" ]]; then
-    cat > "\${index}" <<EOINDEX
----
-title: \${title}
----
-
-# \${title}
-
-{{< section >}}
-EOINDEX
-    continue
-  fi
-
-  if grep -Eq '^(title|menuTitle|linkTitle):' "\${index}"; then
-    continue
-  fi
-
-  if [[ "$(head -n 1 "\${index}")" == '---' ]]; then
-    tmpfile="$(mktemp)"
-    awk -v t="\${title}" '
-      BEGIN { in_front_matter = 0; inserted = 0 }
-      NR == 1 && $0 == "---" { in_front_matter = 1; print; next }
-      in_front_matter && $0 == "---" && !inserted {
-        print "title: " t
-        print
-        inserted = 1
-        in_front_matter = 0
-        next
-      }
-      { print }
-    ' "\${index}" >"\${tmpfile}"
-    mv "\${tmpfile}" "\${index}"
-    continue
-  fi
-
-  tmpfile="$(mktemp)"
-  cat > "\${tmpfile}" <<EOINDEX
----
-title: \${title}
----
-
-EOINDEX
-  cat "\${index}" >> "\${tmpfile}"
-  mv "\${tmpfile}" "\${index}"
-done
-
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
-
-# Generate nginx rewrites for the preview server from the Hugo redirects
-# manifest. Older docs-base images have a redirects binary without the
-# --manifest option, so fall back to scraping dist for alias pages.
-touch dist/preview-redirects.conf
-redirects --base-url "" --manifest dist/redirects.txt dist dist/preview-redirects.conf \
-  || redirects --base-url "" dist dist/preview-redirects.conf \
-  || true
 EOSCRIPT
     chmod +x "${tempfile}"
   }

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -216,6 +216,14 @@ else
         index_files+=("${index_file}:${relative_prefix}")
       fi
     done < <(jq -r '.[] | "\(.index_file) \(.relative_prefix)"' <<<"${SOURCES}")
+
+    mounted_docs_roots=()
+    while read -r docs_root; do
+      if [[ -n "${docs_root}" ]]; then
+        mounted_docs_roots+=("${docs_root}")
+      fi
+    done < <(jq -r '.[] | (.website_directory // "") | select(startswith("content/docs/")) | sub("^content/docs/"; "") | split("/") | .[0]' <<<"${SOURCES}" | sort -u)
+
     cat <<EOSCRIPT >"${tempfile}"
 #!/usr/bin/env bash
 
@@ -252,23 +260,41 @@ EOINDEX
   cat "\${dst}"
 done
 
+mounted_docs_roots=(${mounted_docs_roots[@]})
+
+if [[ "${#mounted_docs_roots[@]}" -gt 0 ]]; then
+  for docs_dir in /hugo/content/docs/*; do
+    if [[ ! -d "\${docs_dir}" ]]; then
+      continue
+    fi
+
+    keep="false"
+    for mounted_root in "\${mounted_docs_roots[@]}"; do
+      if [[ "\${docs_dir##*/}" == "\${mounted_root}" ]]; then
+        keep="true"
+        break
+      fi
+    done
+
+    if [[ "\${keep}" != "true" ]]; then
+      rm -rf "\${docs_dir}"
+    fi
+  done
+fi
+
 fallback_title() {
   local value="\${1//[-_]/ }"
+  local token=""
+  local titled=""
 
-  awk 'BEGIN{ORS=""} {
-    for (i = 1; i <= NF; i++) {
-      if (i > 1) {
-        printf " "
-      }
-      printf toupper(substr($i, 1, 1)) substr($i, 2)
-    }
-  } END{print ""}' <<<"\${value}"
+  for token in \${value}; do
+    titled+="\${token^} "
+  done
+
+  echo "\${titled% }"
 }
 
-# docs-base contains top-level docs directories for many products, but several
-# do not include _index metadata with titles. In deploy previews this creates
-# blank labels in the left docs navigation. Fill missing titles with a fallback
-# based on the directory name.
+# Ensure mounted docs roots always have index metadata with titles.
 for docs_dir in /hugo/content/docs/*; do
   if [[ ! -d "\${docs_dir}" ]]; then
     continue

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -252,6 +252,77 @@ EOINDEX
   cat "\${dst}"
 done
 
+fallback_title() {
+  local value="\${1//[-_]/ }"
+
+  awk 'BEGIN{ORS=""} {
+    for (i = 1; i <= NF; i++) {
+      if (i > 1) {
+        printf " "
+      }
+      printf toupper(substr($i, 1, 1)) substr($i, 2)
+    }
+  } END{print ""}' <<<"\${value}"
+}
+
+# docs-base contains top-level docs directories for many products, but several
+# do not include _index metadata with titles. In deploy previews this creates
+# blank labels in the left docs navigation. Fill missing titles with a fallback
+# based on the directory name.
+for docs_dir in /hugo/content/docs/*; do
+  if [[ ! -d "\${docs_dir}" ]]; then
+    continue
+  fi
+
+  index="\${docs_dir}/_index.md"
+  title="$(fallback_title "\${docs_dir##*/}")"
+
+  if [[ ! -f "\${index}" ]]; then
+    cat > "\${index}" <<EOINDEX
+---
+title: \${title}
+---
+
+# \${title}
+
+{{< section >}}
+EOINDEX
+    continue
+  fi
+
+  if grep -Eq '^(title|menuTitle|linkTitle):' "\${index}"; then
+    continue
+  fi
+
+  if [[ "$(head -n 1 "\${index}")" == '---' ]]; then
+    tmpfile="$(mktemp)"
+    awk -v t="\${title}" '
+      BEGIN { in_front_matter = 0; inserted = 0 }
+      NR == 1 && $0 == "---" { in_front_matter = 1; print; next }
+      in_front_matter && $0 == "---" && !inserted {
+        print "title: " t
+        print
+        inserted = 1
+        in_front_matter = 0
+        next
+      }
+      { print }
+    ' "\${index}" >"\${tmpfile}"
+    mv "\${tmpfile}" "\${index}"
+    continue
+  fi
+
+  tmpfile="$(mktemp)"
+  cat > "\${tmpfile}" <<EOINDEX
+---
+title: \${title}
+---
+
+EOINDEX
+  cat "\${index}" >> "\${tmpfile}"
+  mv "\${tmpfile}" "\${index}"
+done
+
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
 
 # Generate nginx rewrites for the preview server from the Hugo redirects

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -250,8 +250,13 @@ EOPARENT
     parent="\${parent%/*}"
   done
 
+  redirect_title="\${dst%/*}"
+  redirect_title="\${redirect_title##*/}"
+
   cat > "\${dst}" <<EOINDEX
 ---
+title: \${redirect_title}
+menuTitle: \${redirect_title}
 type: redirect
 redirectURL: \${relative_prefix}
 versioned: true

--- a/deploy-preview/build
+++ b/deploy-preview/build
@@ -51,6 +51,14 @@ EOF
 fi
 cat "/hugo/content/docs/${REPO}/_index.md"
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
+
+# Generate nginx rewrites for the preview server from the Hugo redirects
+# manifest. Older docs-base images have a redirects binary without the
+# --manifest option, so fall back to scraping dist for alias pages.
+touch dist/preview-redirects.conf
+redirects --base-url "" --manifest dist/redirects.txt dist dist/preview-redirects.conf \
+  || redirects --base-url "" dist dist/preview-redirects.conf \
+  || true
 '
 # End legacy input.
 else
@@ -245,6 +253,14 @@ EOINDEX
 done
 
 HUGO_SSI=false hugo --environment=docs --destination=dist/ --baseURL= --minify
+
+# Generate nginx rewrites for the preview server from the Hugo redirects
+# manifest. Older docs-base images have a redirects binary without the
+# --manifest option, so fall back to scraping dist for alias pages.
+touch dist/preview-redirects.conf
+redirects --base-url "" --manifest dist/redirects.txt dist dist/preview-redirects.conf \
+  || redirects --base-url "" dist dist/preview-redirects.conf \
+  || true
 EOSCRIPT
     chmod +x "${tempfile}"
   }

--- a/deploy-preview/build-interactive-tutorials
+++ b/deploy-preview/build-interactive-tutorials
@@ -50,6 +50,9 @@ write_page() {
       cat "${website_yaml}"
       echo
     fi
+    if [[ ! -f "${website_yaml}" ]] || ! grep -Eq '^[[:space:]]*layout:[[:space:]]*' "${website_yaml}"; then
+      echo "layout: single-journey"
+    fi
     echo "type: docs"
     echo "title: ${title}"
     echo "description: ${description}"

--- a/deploy-preview/nginx.conf
+++ b/deploy-preview/nginx.conf
@@ -39,6 +39,7 @@ http {
     listen 80;
 
     include /etc/nginx/build.conf;
+    include /usr/share/nginx/dist/preview-redirects.conf;
 
     add_header "X-UA-Compatible" "IE=Edge,chrome=1";
     add_header "Strict-Transport-Security" "max-age=31536000; includeSubDomains; preload";


### PR DESCRIPTION
## What
- Keep deploy preview docs navigation scoped to mounted content only.
- Derive mounted top-level docs roots from SOURCES and remove other /hugo/content/docs/* trees before Hugo build.
- Add title and menuTitle to generated redirect index pages so root sections have labels.

## Testing
- Validated against grafana/mcp-doc-server PR 36 with toolkit_ref set to jdb/deploy-preview.
- Before: sidebar included unrelated product trees and blank labels.
- After: sidebar contains only the mounted mcp-doc-server tree and zero empty docs menu anchors.